### PR TITLE
feat(user): implement GetById UserAccount API with DTO mapping and service result

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/UserAccountsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/UserAccountsController.cs
@@ -21,5 +21,12 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         {
             return await _userAccountService.GetAll();
         }
+
+        // GET api/<UserAccountsController>/{userId}
+        [HttpGet("{userId}")]
+        public async Task<IServiceResult> GetById(Guid userId)
+        {
+            return await _userAccountService.GetById(userId);
+        }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/UserAccountDTOs/UserAccountViewDetailsDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/UserAccountDTOs/UserAccountViewDetailsDto.cs
@@ -1,0 +1,49 @@
+﻿using DakLakCoffeeSupplyChain.Common.Enum.UserAccountEnums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.UserAccountDTOs
+{
+    public class UserAccountViewDetailsDto
+    {
+        public Guid UserId { get; set; }
+
+        public string UserCode { get; set; } = string.Empty;
+
+        public string Email { get; set; } = string.Empty;
+
+        public string PhoneNumber { get; set; } = string.Empty;
+
+        public string Name { get; set; } = string.Empty;
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public Gender Gender { get; set; } = Gender.Unknown;
+
+        public DateOnly? DateOfBirth { get; set; }
+
+        public string Address { get; set; } = string.Empty;
+
+        public string ProfilePictureUrl { get; set; } = string.Empty;
+
+        public bool? EmailVerified { get; set; }
+
+        public bool? IsVerified { get; set; }
+
+        public string LoginType { get; set; } = string.Empty;
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public UserAccountStatus Status { get; set; } = UserAccountStatus.Unknown;
+
+        public string RoleName { get; set; } = string.Empty;
+
+        public DateTime RegistrationDate { get; set; }
+
+        public DateTime? LastLogin { get; set; }
+
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/Enum/UserAccountEnums/Gender.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/Enum/UserAccountEnums/Gender.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Common.Enum.UserAccountEnums
+{
+    public enum Gender
+    {
+        Unknown = 0,
+        Male = 1,
+        Female = 2,
+        Other = 3
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/DakLakCoffeeSupplyChain.Repositories.csproj
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/DakLakCoffeeSupplyChain.Repositories.csproj
@@ -17,8 +17,4 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\DakLakCoffeeSupplyChain.Common\DakLakCoffeeSupplyChain.Common.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IUserAccountRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IUserAccountRepository.cs
@@ -9,6 +9,8 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
 {
     public interface IUserAccountRepository
     {
-        Task<List<UserAccount>> GetAllUserAccountAsync();
+        Task<List<UserAccount>> GetAllUserAccountsAsync();
+
+        Task<UserAccount?> GetUserAccountByIdAsync(Guid userId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/UserAccountRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/UserAccountRepository.cs
@@ -16,7 +16,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
         public UserAccountRepository(DakLakCoffee_SCMContext context)
             => _context = context;
 
-        public async Task<List<UserAccount>> GetAllUserAccountAsync()
+        public async Task<List<UserAccount>> GetAllUserAccountsAsync()
         {
             var userAccounts = await _context.UserAccounts
                 .AsNoTracking()
@@ -25,6 +25,16 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
                 .ToListAsync();
 
             return userAccounts;
+        }
+
+        public async Task<UserAccount?> GetUserAccountByIdAsync(Guid userId)
+        {
+            var user = await _context.UserAccounts
+                .AsNoTracking()
+                .Include(u => u.Role)
+                .FirstOrDefaultAsync(u => u.UserId == userId);
+
+            return user;
         }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IUserAccountService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IUserAccountService.cs
@@ -10,5 +10,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
     public interface IUserAccountService
     {
         Task<IServiceResult> GetAll();
+
+        Task<IServiceResult> GetById(Guid userId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/UserAccountMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/UserAccountMapper.cs
@@ -14,6 +14,11 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
         // Mapper UserAccountViewAllDto
         public static UserAccountViewAllDto MapToUserAccountViewAllDto(this UserAccount entity)
         {
+            // Parse Status string to enum
+            UserAccountStatus status = Enum.TryParse<UserAccountStatus>(entity.Status, true, out var parsedStatus)
+                ? parsedStatus
+                : UserAccountStatus.Unknown;
+
             return new UserAccountViewAllDto
             {
                 UserId = entity.UserId,
@@ -24,11 +29,42 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 RoleName = entity.Role?.RoleName ?? string.Empty,
                 LastLogin = entity.LastLogin,
                 RegistrationDate = entity.RegistrationDate,
+                Status = status
+            };
+        }
 
-                // Parse string to enum, fallback to Unknown
-                Status = Enum.TryParse<UserAccountStatus>(entity.Status, true, out var parsedStatus)
-                    ? parsedStatus
-                    : UserAccountStatus.Unknown
+        // Mapper UserAccountViewDetailsDto
+        public static UserAccountViewDetailsDto MapToUserAccountViewDetailsDto(this UserAccount entity)
+        {
+            // Parse Gender string to enum
+            Gender gender = Enum.TryParse<Gender>(entity.Gender, true, out var parsedGender)
+                ? parsedGender
+                : Gender.Unknown;
+
+            // Parse Status string to enum
+            UserAccountStatus status = Enum.TryParse<UserAccountStatus>(entity.Status, true, out var parsedStatus)
+                ? parsedStatus
+                : UserAccountStatus.Unknown;
+
+            return new UserAccountViewDetailsDto
+            {
+                UserId = entity.UserId,
+                UserCode = entity.UserCode ?? string.Empty,
+                Email = entity.Email ?? string.Empty,
+                PhoneNumber = entity.PhoneNumber ?? string.Empty,
+                Name = entity.Name ?? string.Empty,
+                Gender = gender,
+                DateOfBirth = entity.DateOfBirth,
+                Address = entity.Address ?? string.Empty,
+                ProfilePictureUrl = entity.ProfilePictureUrl ?? string.Empty,
+                EmailVerified = entity.EmailVerified,
+                IsVerified = entity.IsVerified,
+                LoginType = entity.LoginType ?? string.Empty,
+                Status = status,
+                RoleName = entity.Role?.RoleName ?? string.Empty,
+                RegistrationDate = entity.RegistrationDate,
+                LastLogin = entity.LastLogin,
+                UpdatedAt = entity.UpdatedAt
             };
         }
     }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/UserAccountService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/UserAccountService.cs
@@ -25,7 +25,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
         public async Task<IServiceResult> GetAll()
         {
 
-            var userAccounts = await _unitOfWork.UserAccountRepository.GetAllUserAccountAsync();
+            var userAccounts = await _unitOfWork.UserAccountRepository.GetAllUserAccountsAsync();
 
             if (userAccounts == null || !userAccounts.Any())
             {
@@ -45,6 +45,30 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                     Const.SUCCESS_READ_CODE,
                     Const.SUCCESS_READ_MSG,
                     userAccountDtos
+                );
+            }
+        }
+
+        public async Task<IServiceResult> GetById(Guid userId)
+        {
+            var user = await _unitOfWork.UserAccountRepository.GetUserAccountByIdAsync(userId);
+
+            if (user == null)
+            {
+                return new ServiceResult(
+                    Const.WARNING_NO_DATA_CODE,
+                    Const.WARNING_NO_DATA_MSG,
+                    new UserAccountViewDetailsDto()
+                );
+            }
+            else
+            {
+                var userDto = user.MapToUserAccountViewDetailsDto();
+
+                return new ServiceResult(
+                    Const.SUCCESS_READ_CODE,
+                    Const.SUCCESS_READ_MSG,
+                    userDto
                 );
             }
         }


### PR DESCRIPTION
### Overview
This pull request adds the full implementation of the `GetById` API for `UserAccount`, enabling retrieval of detailed account information by `UserId`.

---

### Changes Included
- Added `UserAccountViewDetailsDto` for detail-level data projection
- Implemented `GetUserAccountByIdAsync(Guid)` in `UserAccountRepository`
- Mapped entity to DTO in `UserAccountMapper`
- Added `GetById` method in `UserAccountService` with `ServiceResult` response
- Created `GET /api/UserAccounts/{userId}` endpoint in `UserAccountsController`

---

### How to test
- Call endpoint: `GET /api/UserAccounts/{userId}`
- Example: `GET /api/UserAccounts/3fa85f64-5717-4562-b3fc-2c963f66afa6`
- Should return: user profile with Role, Status, and full details

---

### Notes
- Ensures clean separation via layered architecture (Controller → Service → Repository)
- Uses enum parsing for `Status` and `Gender` with safe fallback
- Compatible with `UserAccountViewAllDto` in GetAll flow
