### PR TITLE
refactor(repository): apply UnitOfWork pattern by removing SaveChanges from GenericRepository

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Base/GenericRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Base/GenericRepository.cs
@@ -35,30 +35,42 @@ namespace DakLakCoffeeSupplyChain.Repositories.Base
         public void Create(T entity)
         {
             _context.Add(entity);
-            _context.SaveChanges();
+            //_context.SaveChanges();
         }
 
-        public async Task<int> CreateAsync(T entity)
+        public async Task CreateAsync(T entity)
         {
-            _context.Add(entity);
-
-            return await _context.SaveChangesAsync();
+            await _context.Set<T>().AddAsync(entity);
         }
+
+        //public async Task<int> CreateAsync(T entity)
+        //{
+        //    _context.Add(entity);
+
+        //    return await _context.SaveChangesAsync();
+        //}
 
         public void Update(T entity)
         {
             var tracker = _context.Attach(entity);
             tracker.State = EntityState.Modified;
-            _context.SaveChanges();
+            //_context.SaveChanges();
         }
 
-        public async Task<int> UpdateAsync(T entity)
+        public async Task UpdateAsync(T entity)
         {
+            await Task.Yield();                     // để tránh warning "method lacks 'await'"
             var tracker = _context.Attach(entity);
             tracker.State = EntityState.Modified;
-
-            return await _context.SaveChangesAsync();
         }
+
+        //public async Task<int> UpdateAsync(T entity)
+        //{
+        //    var tracker = _context.Attach(entity);
+        //    tracker.State = EntityState.Modified;
+
+        //    return await _context.SaveChangesAsync();
+        //}
 
         public bool Remove(T entity)
         {
@@ -68,13 +80,19 @@ namespace DakLakCoffeeSupplyChain.Repositories.Base
             return true;
         }
 
-        public async Task<bool> RemoveAsync(T entity)
+        public async Task RemoveAsync(T entity)
         {
+            await Task.Yield();
             _context.Remove(entity);
-            await _context.SaveChangesAsync();
-
-            return true;
         }
+
+        //public async Task<bool> RemoveAsync(T entity)
+        //{
+        //    _context.Remove(entity);
+        //    await _context.SaveChangesAsync();
+
+        //    return true;
+        //}
 
         public T GetById(int id)
         {

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Base/IGenericRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Base/IGenericRepository.cs
@@ -26,11 +26,17 @@ namespace DakLakCoffeeSupplyChain.Repositories.Base
 
         Task<T> GetByIdAsync(Guid id);
 
-        Task<int> CreateAsync(T entity);
+        Task CreateAsync(T entity);
 
-        Task<int> UpdateAsync(T entity);
+        //Task<int> CreateAsync(T entity);
 
-        Task<bool> RemoveAsync(T entity);
+        Task UpdateAsync(T entity);
+
+        //Task<int> UpdateAsync(T entity);
+
+        Task RemoveAsync(T entity);
+
+        //Task<bool> RemoveAsync(T entity);
 
         void PrepareCreate(T entity);
 

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/IUnitOfWork.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/IUnitOfWork.cs
@@ -9,6 +9,8 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
 {
     public interface IUnitOfWork
     {
+        Task<int> SaveChangesAsync();
+
         IRoleRepository RoleRepository { get; }
 
         IUserAccountRepository UserAccountRepository { get; }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/UnitOfWork.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/UnitOfWork.cs
@@ -20,6 +20,11 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
         public UnitOfWork()
             => context ??= new DakLakCoffee_SCMContext();
 
+        public async Task<int> SaveChangesAsync()
+        {
+            return await context.SaveChangesAsync();
+        }
+
         public IRoleRepository RoleRepository
         {
             get

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/UserAccountService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/UserAccountService.cs
@@ -148,7 +148,8 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 var newUser = userDto.MapToUserAccountCreateDto(passwordHash, userCode, role.RoleId);
 
                 // Save data to database
-                var result = await _unitOfWork.UserAccountRepository.CreateAsync(newUser);
+                await _unitOfWork.UserAccountRepository.CreateAsync(newUser);
+                var result = await _unitOfWork.SaveChangesAsync();
 
                 if (result > 0)
                 {


### PR DESCRIPTION
### 🔧 What’s Changed

This pull request **refactors the repository layer** to properly follow the **Unit of Work pattern**.

---

### ✅ Summary of Changes

- Removed all direct `SaveChanges()` and `SaveChangesAsync()` calls from `GenericRepository<T>`.
- Updated `CreateAsync`, `UpdateAsync`, and `RemoveAsync` to **only prepare operations**, not commit.
- Introduced use of `UnitOfWork.SaveChangesAsync()` for centralized transaction control.
- Added `await Task.Yield();` in async methods to prevent compiler warnings while preserving async behavior.
- Adjusted `IGenericRepository<T>` interface to match updated method signatures.
- Updated `UserAccountService` to call `SaveChangesAsync()` explicitly after repository calls.

---

### 📌 Why This Matters

Previously, each repository method saved data independently. This violated the Unit of Work principle and broke transactional consistency. Now:

- Multiple changes can be committed as **one transaction**.
- Easier to maintain and test service logic.
- Enables rollback if one step fails (e.g. create A, then create B → if B fails, A is not saved either).

---

### 🧪 Impact

- This PR affects: `GenericRepository`, `IGenericRepository`, `IUnitOfWork`, `UnitOfWork`, `UserAccountService`.
- No impact
