### PR TITLE
refactor(service): change delete result to Task<int> in UserAccount and Product services

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProductService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProductService.cs
@@ -129,7 +129,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                     var result = await _unitOfWork.SaveChangesAsync();
 
                     // Kiểm tra kết quả
-                    if (result == Const.SUCCESS_DELETE_CODE)
+                    if (result > 0)
                     {
                         return new ServiceResult(
                             Const.SUCCESS_DELETE_CODE,

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/UserAccountService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/UserAccountService.cs
@@ -222,7 +222,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                     var result = await _unitOfWork.SaveChangesAsync();
 
                     // Kiểm tra xem việc lưu có thành công không
-                    if (result == Const.SUCCESS_DELETE_CODE)
+                    if (result > 0)
                     {
                         return new ServiceResult(
                             Const.SUCCESS_DELETE_CODE,


### PR DESCRIPTION
### 🔄 What’s changed

Refactored `DeleteAsync` logic in `UserAccountService` and `ProductService`:

- Changed return type from `Task<bool>` ➜ `Task<int>`
- Updated condition check from `if (result == Const.SUCCESS_DELETE_CODE)` ➜ `if (result > 0)`

---

### ✅ Why this change?

- Aligns with EF Core's `SaveChangesAsync()` which returns the number of affected rows
- Allows for better control and error handling based on how many entities are actually deleted
- Makes the code more consistent across create/update/delete operations

---

### 📦 Affected Services

- `UserAccountService`
- `ProductService`
