### PR TITLE
Add Delete functionality for CropSeason with related CropSeasonDetails

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropSeasonController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropSeasonController.cs
@@ -79,5 +79,19 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             return NotFound(result.Message);
         }
 
+        [HttpDelete("{cropSeasonId}")]
+        public async Task<IActionResult> DeleteCropSeason(Guid cropSeasonId)
+        {
+            var result = await _cropSeasonService.DeleteById(cropSeasonId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok(result.Message);
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound(result.Message);
+
+            return StatusCode(500, result.Message);
+        }
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonDeleteDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonDeleteDto.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDTOs
+{
+    public class CropSeasonDeleteDto
+    {
+        [Required(ErrorMessage = "ID mùa vụ là bắt buộc.")]
+        public Guid CropSeasonId { get; set; }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/UserAccountDTOs/UserAccountDeleteDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/UserAccountDTOs/UserAccountDeleteDto.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿    using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropSeasonRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropSeasonRepository.cs
@@ -14,5 +14,8 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
 
         Task<CropSeason?> GetWithDetailsByIdAsync(Guid cropSeasonId);
 
+        Task DeleteCropSeasonDetailsBySeasonIdAsync(Guid cropSeasonId);
+
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonRepository.cs
@@ -39,4 +39,13 @@ public class CropSeasonRepository : GenericRepository<CropSeason>, ICropSeasonRe
             .FirstOrDefaultAsync(cs => cs.CropSeasonId == cropSeasonId);
     }
 
+    public async Task DeleteCropSeasonDetailsBySeasonIdAsync(Guid cropSeasonId)
+    {
+        var details = await _context.CropSeasonDetails
+            .Where(d => d.CropSeasonId == cropSeasonId)
+            .ToListAsync();
+
+        _context.CropSeasonDetails.RemoveRange(details);
+    }
+
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropSeasonService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropSeasonService.cs
@@ -9,6 +9,6 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> GetById(Guid id);
         Task<IServiceResult> Create(CropSeasonCreateDto dto);
         Task<IServiceResult> Update(CropSeasonUpdateDto dto);
-
+        Task<IServiceResult> DeleteById(Guid cropSeasonId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropSeasonService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropSeasonService.cs
@@ -171,6 +171,22 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             return new ServiceResult(Const.SUCCESS_UPDATE_CODE, "Cập nhật thành công");
         }
 
+        public async Task<IServiceResult> DeleteById(Guid cropSeasonId)
+        {
+            var existing = await _unitOfWork.CropSeasonRepository.GetByIdAsync(cropSeasonId);
+            if (existing == null)
+                return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Không tìm thấy mùa vụ.");
+
+            // Xóa chi tiết trước
+            await _unitOfWork.CropSeasonRepository.DeleteCropSeasonDetailsBySeasonIdAsync(cropSeasonId);
+
+            // Xóa mùa vụ
+            _unitOfWork.CropSeasonRepository.PrepareRemove(existing);
+
+            await _unitOfWork.SaveChangesAsync();
+
+            return new ServiceResult(Const.SUCCESS_DELETE_CODE, "Xóa mùa vụ thành công.");
+        }
 
     }
 }


### PR DESCRIPTION
- Implemented DeleteById in CropSeasonService that:
  - Validates if the CropSeason exists
  - Deletes all related CropSeasonDetails
  - Removes the CropSeason entity
- Fixed return type mismatch in DeleteById to match ICropSeasonService interface
- No mapping needed for DeleteDto as only CropSeasonId is used