### PR TITLE
feat(flow4): implement get all inbound requests and standardize appro…

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/WarehouseInboundRequestsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/WarehouseInboundRequestsController.cs
@@ -34,6 +34,13 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             var result = await _service.ApproveRequestAsync(id, staffUserId);
             return StatusCode(result.Status, result);
         }
+        [HttpGet]
+        [Authorize(Roles = "BusinessStaff,Administrator")]
+        public async Task<IActionResult> GetAll()
+        {
+            var result = await _service.GetAllAsync();
+            return StatusCode(result.Status, result);
+        }
 
 
 

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IWarehouseInboundRequestRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IWarehouseInboundRequestRepository.cs
@@ -14,6 +14,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
         Task<WarehouseInboundRequest?> GetByIdWithFarmerAsync(Guid id);
         Task<WarehouseInboundRequest?> GetByIdWithBatchAsync(Guid id);
         Task<List<WarehouseInboundRequest>> GetAllPendingAsync();
+        Task<List<WarehouseInboundRequest>> GetAllWithIncludesAsync();
 
         void Update(WarehouseInboundRequest entity);
         void Delete(WarehouseInboundRequest entity);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/WarehouseInboundRequestRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/WarehouseInboundRequestRepository.cs
@@ -43,6 +43,15 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
                 .Include(r => r.Farmer)
                 .ToListAsync();
         }
+        public async Task<List<WarehouseInboundRequest>> GetAllWithIncludesAsync()
+        {
+            return await _context.WarehouseInboundRequests
+                .Include(r => r.Farmer).ThenInclude(f => f.User)
+                .Include(r => r.BusinessStaff).ThenInclude(s => s.User)
+                .Include(r => r.Batch)
+                .OrderByDescending(r => r.CreatedAt)
+                .ToListAsync();
+        }
 
         public void Update(WarehouseInboundRequest entity)
         {

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IWarehouseInboundRequestService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IWarehouseInboundRequestService.cs
@@ -12,6 +12,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
     {
         Task<IServiceResult> CreateRequestAsync(Guid farmerId, WarehouseInboundRequestCreateDto dto);
         Task<IServiceResult> ApproveRequestAsync(Guid requestId, Guid staffUserId);
+        Task<IServiceResult> GetAllAsync();
 
     }
 }


### PR DESCRIPTION
Added: GET /api/warehouseinboundrequests – to retrieve all inbound requests with related data (farmer, batch, staff).
Updated: ApproveRequestAsync() logic to use standardized status codes from Const.cs:

SUCCESS_UPDATE_CODE when approved successfully

FAIL_UPDATE_CODE if already processed or invalid

WARNING_NO_DATA_CODE if request not found

