### PR TITLE
feat(role): implement soft delete API and filter inactive roles from GetAll

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/RolesController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/RolesController.cs
@@ -72,7 +72,7 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
         // PUT api/<RolesController>/{roleId}
         [HttpPut("{roleId}")]
-        public async Task<IActionResult> UpdateUserAccountAsync(int roleId, [FromBody] RoleUpdateDto roleDto)
+        public async Task<IActionResult> UpdateRoleAsync(int roleId, [FromBody] RoleUpdateDto roleDto)
         {
             // So sánh route id với dto id để đảm bảo tính nhất quán
             if (roleId != roleDto.RoleId)
@@ -109,6 +109,24 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             if (result.Status == Const.FAIL_DELETE_CODE)
                 return Conflict("Xóa thất bại.");
+
+            return StatusCode(500, result.Message);
+        }
+
+        // PATCH: api/<RolesController>/soft-delete/{roleId}
+        [HttpPatch("soft-delete/{roleId}")]
+        public async Task<IActionResult> SoftDeleteRoleByIdAsync(int roleId)
+        {
+            var result = await _roleService.SoftDeleteById(roleId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok("Xóa mềm thành công.");
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy vai trò.");
+
+            if (result.Status == Const.FAIL_DELETE_CODE)
+                return Conflict("Xóa mềm thất bại.");
 
             return StatusCode(500, result.Message);
         }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IRoleService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IRoleService.cs
@@ -20,5 +20,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> Update(RoleUpdateDto roleDto);
 
         Task<IServiceResult> DeleteById(int roleId);
+
+        Task<IServiceResult> SoftDeleteById(int roleId);
     }
 }


### PR DESCRIPTION
### ✅ Summary
Implemented soft delete functionality for the `Role` module and updated the GetAll API to exclude inactive roles.

---

### ✨ What’s added
- `PATCH /api/roles/soft-delete/{roleId}`: Soft delete API to mark a role as inactive instead of permanently removing it.
- Logic to filter out soft-deleted roles (with status `Inactive`) in `GetAll()` API.

---

### ♻️ Changes
- Modified `RoleService.GetAll()` to only return roles with active status.
- Added `SoftDeleteById` method to `IRoleService` and implemented logic in service & controller.

---

### 🔒 Authorization
- Only accessible by `Admin` (as enforced by `[Authorize(Roles = "Admin")]` on controller).

---

### 🧪 How to test
1. Call `GET /api/roles` → Should only show roles with status `Active`.
2. Call `PATCH /api/roles/soft-delete/{id}` → Should return success if role exists and is not already soft-deleted.
3. Re-call `GET /api/roles` → The soft-deleted role should no longer be listed.

---

### 📌 Note
- This is a **non-breaking change**.
- Soft-deleted roles are not removed from the database and can be audited or restored later if needed.
