### PR TITLE
feat(inbound-request): add cancel (farmer) and reject (staff) functio…

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/WarehouseInboundRequestsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/WarehouseInboundRequestsController.cs
@@ -50,6 +50,24 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             var result = await _service.GetByIdAsync(id);
             return StatusCode(result.Status, result);
         }
+        [HttpPut("{id}/cancel")]
+        [Authorize(Roles = "Farmer")]
+        public async Task<IActionResult> CancelRequest(Guid id)
+        {
+            var farmerId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier));
+            var result = await _service.CancelRequestAsync(id, farmerId);
+            return StatusCode(result.Status, result);
+        }
+
+        [HttpPut("{id}/reject")]
+        [Authorize(Roles = "BusinessStaff")]
+        public async Task<IActionResult> RejectRequest(Guid id)
+        {
+            var staffId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier));
+            var result = await _service.RejectRequestAsync(id, staffId);
+            return StatusCode(result.Status, result);
+        }
+
 
 
 

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IWarehouseInboundRequestService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IWarehouseInboundRequestService.cs
@@ -14,6 +14,8 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> ApproveRequestAsync(Guid requestId, Guid staffUserId);
         Task<IServiceResult> GetAllAsync();
         Task<IServiceResult> GetByIdAsync(Guid requestId);
+        Task<IServiceResult> CancelRequestAsync(Guid requestId, Guid farmerUserId);
+        Task<IServiceResult> RejectRequestAsync(Guid requestId, Guid staffUserId);
 
     }
 }


### PR DESCRIPTION
- Implemented cancel request logic for farmers.
- Added reject request flow for business staff.
- Updated service layer to handle status validation and permission logic.
- Ensured consistent status handling for Pending requests only.

This is part of Flow 4: Warehouse Management.