### PR TITLE
feat(user): implement soft delete and filter inactive users in GetAll API

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/UserAccountsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/UserAccountsController.cs
@@ -3,6 +3,7 @@ using DakLakCoffeeSupplyChain.Common.DTOs.UserAccountDTOs;
 using DakLakCoffeeSupplyChain.Repositories.Models;
 using DakLakCoffeeSupplyChain.Services.Base;
 using DakLakCoffeeSupplyChain.Services.IServices;
+using DakLakCoffeeSupplyChain.Services.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Query;
@@ -112,6 +113,24 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             if (result.Status == Const.FAIL_DELETE_CODE)
                 return Conflict("Xóa thất bại.");
+
+            return StatusCode(500, result.Message);
+        }
+
+        // PATCH: api/<UserAccountsController>/soft-delete/{userId}
+        [HttpPatch("soft-delete/{userId}")]
+        public async Task<IActionResult> SoftDeleteUserAccountByIdAsync(Guid userId)
+        {
+            var result = await _userAccountService.SoftDeleteById(userId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok("Xóa mềm thành công.");
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy người dùng.");
+
+            if (result.Status == Const.FAIL_DELETE_CODE)
+                return Conflict("Xóa mềm thất bại.");
 
             return StatusCode(500, result.Message);
         }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IUserAccountService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IUserAccountService.cs
@@ -19,5 +19,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> Update(UserAccountUpdateDto userDto);
 
         Task<IServiceResult> DeleteById(Guid userId);
+
+        Task<IServiceResult> SoftDeleteById(Guid userId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/RoleService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/RoleService.cs
@@ -15,6 +15,7 @@ using DakLakCoffeeSupplyChain.Common.DTOs.UserAccountDTOs;
 using DakLakCoffeeSupplyChain.Common.Helpers;
 using DakLakCoffeeSupplyChain.Services.Generators;
 using DakLakCoffeeSupplyChain.Common.Enum.RoleEnums;
+using DakLakCoffeeSupplyChain.Repositories.Models;
 
 namespace DakLakCoffeeSupplyChain.Services.Services
 {
@@ -30,15 +31,12 @@ namespace DakLakCoffeeSupplyChain.Services.Services
         public async Task<IServiceResult> GetAll()
         {
             // Lấy danh sách vai trò từ repository
-            var roles = await _unitOfWork.RoleRepository.GetAllAsync();
-
-            // Lọc ra các vai trò chưa bị xóa mềm (IsDeleted = false)
-            var validRoles = roles
-                .Where(role => !role.IsDeleted)
-                .ToList();
+            var roles = await _unitOfWork.RoleRepository.GetAllAsync(
+                predicate: role => role.IsDeleted != true
+            );
 
             // Kiểm tra nếu không có dữ liệu
-            if (!validRoles.Any())
+            if (roles == null || !roles.Any())
             {
                 return new ServiceResult(
                     Const.WARNING_NO_DATA_CODE,
@@ -49,7 +47,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             else
             {
                 // Chuyển đổi sang danh sách DTO để trả về cho client
-                var roleDtos = validRoles
+                var roleDtos = roles
                     .Select(roles => roles.MapToRoleViewAllDto())
                     .ToList();
 
@@ -274,7 +272,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                     role.IsDeleted = true;
                     role.UpdatedAt = DateTime.Now;
 
-                    // Cập nhật vai trò ở repository
+                    // Cập nhật xoá mềm vai trò ở repository
                     await _unitOfWork.RoleRepository.UpdateAsync(role);
 
                     // Lưu thay đổi


### PR DESCRIPTION
### 💡 Summary
Implemented **soft delete** for the `UserAccount` entity and updated the `GetAll` API to **exclude deleted users** (`IsDeleted = true`).

---

### ✅ Changes
- Added soft delete API (`PATCH /api/user-accounts/{id}`)
  - Instead of permanently deleting, sets `IsDeleted = true`
- Updated `UserAccountRepository.GetAllAsync` to automatically filter `IsDeleted = false`
- Modified `UserAccountService.GetAll` to avoid manual filtering
- `IsDeleted` is excluded from all DTOs (fully hidden from frontend)
- Ensured compliance with RESTful standards and improved data integrity

---

### 📦 Affected Modules
- `UserAccount`
- Repository
- Service
- Controller

---

### 📌 Notes
- No DTO is used for soft delete; only the `ID` is required
- Can be extended in the future to support **restore** functionality if needed
