### PR TITLE
feat(business-manager): implement create API with validation, code gen, and 3-layer structure

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessManagersController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessManagersController.cs
@@ -1,4 +1,6 @@
 ﻿using DakLakCoffeeSupplyChain.Common;
+using DakLakCoffeeSupplyChain.Common.DTOs.BusinessManagerDTOs;
+using DakLakCoffeeSupplyChain.Common.DTOs.RoleDTOs;
 using DakLakCoffeeSupplyChain.Services.IServices;
 using DakLakCoffeeSupplyChain.Services.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -49,6 +51,25 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
                 return NotFound(result.Message);     // Trả 404 nếu không tìm thấy
 
             return StatusCode(500, result.Message);  // Lỗi hệ thống
+        }
+
+        // POST api/<BusinessManagersController>
+        [HttpPost]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> CreateBusinessManagerAsync([FromBody] BusinessManagerCreateDto businessManagerCreateDto, [FromQuery] Guid userId)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var result = await _bussinessManagerService.Create(businessManagerCreateDto, userId);
+
+            if (result.Status == Const.SUCCESS_CREATE_CODE)
+                return CreatedAtAction(nameof(GetById), new { managerId = ((BusinessManagerViewDetailsDto)result.Data).ManagerId }, result.Data);
+
+            if (result.Status == Const.FAIL_CREATE_CODE)
+                return Conflict(result.Message);
+
+            return StatusCode(500, result.Message);
         }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Program.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Program.cs
@@ -24,7 +24,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddScoped<IPasswordHasher, PasswordHasher>();
 
 // Đăng ký service tạo mã định danh
-builder.Services.AddScoped<ICodeGenerator, UserCodeGenerator>();
+builder.Services.AddScoped<ICodeGenerator, CodeGenerator>();
 builder.Services.AddScoped<ICropSeasonCodeGenerator, CropSeasonCodeGenerator>();
 
 // Unit of Work pattern: quản lý Transaction + Repository access

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/BusinessManagerDTOs/BusinessManagerCreateDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/BusinessManagerDTOs/BusinessManagerCreateDto.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.BusinessManagerDTOs
+{
+    public class BusinessManagerCreateDto
+    {
+        [Required(ErrorMessage = "Company name is required.")]
+        [StringLength(100, ErrorMessage = "Company name must be at most 100 characters.")]
+        public string CompanyName { get; set; } = string.Empty;
+
+        [StringLength(50, ErrorMessage = "Position must be at most 50 characters.")]
+        public string Position { get; set; } = string.Empty;
+
+        [StringLength(100, ErrorMessage = "Department must be at most 100 characters.")]
+        public string Department { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Company address is required.")]
+        [StringLength(255, ErrorMessage = "Company address must be at most 255 characters.")]
+        public string CompanyAddress { get; set; } = string.Empty;
+
+        [StringLength(50, ErrorMessage = "Tax ID must be at most 50 characters.")]
+        public string TaxId { get; set; } = string.Empty;
+
+        [StringLength(255, ErrorMessage = "Website must be at most 255 characters.")]
+        [Url(ErrorMessage = "Website must be a valid URL.")]
+        public string? Website { get; set; }
+
+        [Required(ErrorMessage = "Contact email is required.")]
+        [StringLength(100, ErrorMessage = "Contact email must be at most 100 characters.")]
+        [EmailAddress(ErrorMessage = "Contact email must be a valid email address.")]
+        public string ContactEmail { get; set; } = string.Empty;
+
+        [StringLength(255, ErrorMessage = "Business license URL must be at most 255 characters.")]
+        [Url(ErrorMessage = "Business license URL must be a valid URL.")]
+        public string? BusinessLicenseUrl { get; set; }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IBusinessManagerRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IBusinessManagerRepository.cs
@@ -10,5 +10,10 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
 {
     public interface IBusinessManagerRepository : IGenericRepository<BusinessManager>
     {
+        Task<BusinessManager?> GetByUserIdAsync(Guid userId);
+
+        Task<BusinessManager?> GetByTaxIdAsync(string taxId);
+
+        Task<int> CountBusinessManagersRegisteredInYearAsync(int year);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/BusinessManagerRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/BusinessManagerRepository.cs
@@ -2,6 +2,7 @@
 using DakLakCoffeeSupplyChain.Repositories.DBContext;
 using DakLakCoffeeSupplyChain.Repositories.IRepositories;
 using DakLakCoffeeSupplyChain.Repositories.Models;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,5 +17,28 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
 
         public BusinessManagerRepository(DakLakCoffee_SCMContext context)
             => _context = context;
+
+        // Lấy BusinessManager theo UserId (chỉ bản ghi chưa bị xóa mềm)
+        public async Task<BusinessManager?> GetByUserIdAsync(Guid userId)
+        {
+            return await _context.BusinessManagers
+                                 .FirstOrDefaultAsync(m => m.UserId == userId && !m.IsDeleted);
+        }
+
+        // Lấy BusinessManager theo mã số thuế (TaxId)
+        public async Task<BusinessManager?> GetByTaxIdAsync(string taxId)
+        {
+            return await _context.BusinessManagers
+                .AsNoTracking()
+                .FirstOrDefaultAsync(bm => bm.TaxId == taxId && !bm.IsDeleted);
+        }
+
+        // Đếm số BusinessManager đã đăng ký trong một năm
+        public async Task<int> CountBusinessManagersRegisteredInYearAsync(int year)
+        {
+            return await _context.BusinessManagers
+                .AsNoTracking()
+                .CountAsync(bm => bm.CreatedAt.Year == year && !bm.IsDeleted);
+        }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Generators/CodeGenerator.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Generators/CodeGenerator.cs
@@ -10,11 +10,11 @@ using System.Threading.Tasks;
 
 namespace DakLakCoffeeSupplyChain.Services.Generators
 {
-    public class UserCodeGenerator : ICodeGenerator
+    public class CodeGenerator : ICodeGenerator
     {
         private readonly IUnitOfWork _unitOfWork;
 
-        public UserCodeGenerator(IUnitOfWork unitOfWork)
+        public CodeGenerator(IUnitOfWork unitOfWork)
             => _unitOfWork = unitOfWork;
 
         public async Task<string> GenerateUserCodeAsync()
@@ -25,6 +25,16 @@ namespace DakLakCoffeeSupplyChain.Services.Generators
             var count = await _unitOfWork.UserAccountRepository.CountUsersRegisteredInYearAsync(currentYear);
 
             return $"USR-{currentYear}-{(count + 1):D4}";
+        }
+
+        public async Task<string> GenerateManagerCodeAsync()
+        {
+            var currentYear = DateTime.UtcNow.Year;
+
+            // Đếm số manager tạo trong năm
+            var count = await _unitOfWork.BusinessManagerRepository.CountBusinessManagersRegisteredInYearAsync(currentYear);
+
+            return $"BM-{currentYear}-{(count + 1):D4}";
         }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Generators/ICodeGenerator.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Generators/ICodeGenerator.cs
@@ -10,5 +10,6 @@ namespace DakLakCoffeeSupplyChain.Services.Generators
     {
         Task<string> GenerateUserCodeAsync();
 
+        Task<string> GenerateManagerCodeAsync();
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBussinessManagerService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBussinessManagerService.cs
@@ -1,4 +1,6 @@
-﻿using DakLakCoffeeSupplyChain.Services.Base;
+﻿using DakLakCoffeeSupplyChain.Common.DTOs.BusinessManagerDTOs;
+using DakLakCoffeeSupplyChain.Common.DTOs.RoleDTOs;
+using DakLakCoffeeSupplyChain.Services.Base;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,5 +14,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> GetAll();
 
         Task<IServiceResult> GetById(Guid managerId);
+
+        Task<IServiceResult> Create(BusinessManagerCreateDto businessManagerDto, Guid userId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/BusinessManagerMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/BusinessManagerMapper.cs
@@ -49,5 +49,28 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 PhoneNumber = manager.User?.PhoneNumber ?? string.Empty
             };
         }
+
+        // Mapper BusinessManagerCreateDto
+        public static BusinessManager MapToNewBusinessManager(this BusinessManagerCreateDto dto, Guid userId, string managerCode)
+        {
+            return new BusinessManager
+            {
+                ManagerId = Guid.NewGuid(),
+                UserId = userId,
+                ManagerCode = managerCode,
+                CompanyName = dto.CompanyName,
+                Position = dto.Position,
+                Department = dto.Department,
+                CompanyAddress = dto.CompanyAddress,
+                TaxId = dto.TaxId,
+                Website = dto.Website,
+                ContactEmail = dto.ContactEmail,
+                BusinessLicenseUrl = dto.BusinessLicenseUrl,
+                IsCompanyVerified = false,                    // Mặc định khi đăng ký là false
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                IsDeleted = false
+            };
+        }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/RoleMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/RoleMapper.cs
@@ -56,7 +56,8 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 Description = dto.Description,
                 Status = dto.Status.ToString(), // enum → string
                 CreatedAt = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow
+                UpdatedAt = DateTime.UtcNow,
+                IsDeleted = false
             };
         }
 

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/UserAccountMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/UserAccountMapper.cs
@@ -87,6 +87,7 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 EmailVerified = true,         // Admin tạo thì email được xem là xác thực
                 IsVerified = true,            // Có thể xem như đã duyệt
                 VerificationCode = null,      // Không cần tạo mã xác minh
+                IsDeleted = false
             };
         }
 


### PR DESCRIPTION
## 🚀 What’s this PR about?

This Pull Request implements the **Create BusinessManager API**, including full 3-layer architecture (Controller → Service → Repository). It allows admin users to register new business managers into the system.

---

## ✅ Changes Included

- Add `BusinessManagerCreateDto` with full validation annotations.
- Implement logic in `BusinessManagerService.Create()`:
  - Validate user existence, role, and soft-deletion.
  - Check for duplicate BusinessManager by `UserId`.
  - Check for existing company using `TaxId`.
  - Generate a unique `ManagerCode` using the current year and auto-incremented index.
  - Return enriched response including:
    - `Email`, `FullName`, `PhoneNumber` from `UserAccount`.

- Add `CodeGenerator` class for user code creation (replace old `UserCodeGenerator`).
- Update `BusinessManagerRepository` and `IBusinessManagerRepository` with:
  - `GetByUserIdAsync()`
  - `GetByTaxIdAsync()`
  - `CountBusinessManagersRegisteredInYearAsync()`

---

## 🔒 Permission Check

- ✅ API restricted to `Admin` role (`[Authorize(Roles = "Admin")]`)

---

## 🧪 How to test

1. Call `POST /api/BusinessManagers?userId={id}` with a valid user ID.
2. Provide valid JSON body using `BusinessManagerCreateDto`.
3. Expect:
   - `201 Created` on success
   - `409 Conflict` if user is already a manager or tax ID is duplicated
   - `403 Forbidden` if user is not admin
   - `400 BadRequest` if validation fails

---

## 🧠 Notes

- Role is included in EF query to avoid `NullReferenceException`.
- `IsDeleted` is checked to skip soft-deleted users.
- ManagerCode format: `BM-2025-0001`, can be extended to include company tag.
