### PR TITLE
feat(business-manager): implement delete API with service, controller, and error handling

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessManagersController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessManagersController.cs
@@ -76,6 +76,25 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             return StatusCode(500, result.Message);
         }
 
+        // DELETE api/<BusinessManagersController>/{managerId}
+        [HttpDelete("{managerId}")]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> DeleteRoleByIdAsync(Guid managerId)
+        {
+            var result = await _businessManagerService.DeleteById(managerId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok("Xóa thành công.");
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy quản lý doanh nghiệp.");
+
+            if (result.Status == Const.FAIL_DELETE_CODE)
+                return Conflict("Xóa thất bại.");
+
+            return StatusCode(500, result.Message);
+        }
+
         // PATCH: api/<BusinessManagersController>/soft-delete/{managerId}
         [HttpPatch("soft-delete/{managerId}")]
         [Authorize(Roles = "Admin,BusinessManager")]

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessManagerService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessManagerService.cs
@@ -17,6 +17,8 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Create(BusinessManagerCreateDto businessManagerDto, Guid userId);
 
+        Task<IServiceResult> DeleteById(Guid managerId);
+
         Task<IServiceResult> SoftDeleteById(Guid managerId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/BusinessManagerService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/BusinessManagerService.cs
@@ -179,6 +179,61 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             }
         }
 
+        public async Task<IServiceResult> DeleteById(Guid managerId)
+        {
+            try
+            {
+                // Tìm quản lý doanh nghiệp theo ID
+                var businessManager = await _unitOfWork.BusinessManagerRepository.GetByIdAsync(
+                    predicate: bm => bm.ManagerId == managerId,
+                    include: query => query
+                       .Include(bm => bm.User),
+                    asNoTracking: true
+                );
+
+                // Kiểm tra nếu không tồn tại
+                if (businessManager == null)
+                {
+                    return new ServiceResult(
+                        Const.WARNING_NO_DATA_CODE,
+                        Const.WARNING_NO_DATA_MSG
+                    );
+                }
+                else
+                {
+                    // Xóa quản lý doanh nghiệp khỏi repository
+                    await _unitOfWork.BusinessManagerRepository.RemoveAsync(businessManager);
+
+                    // Lưu thay đổi
+                    var result = await _unitOfWork.SaveChangesAsync();
+
+                    // Kiểm tra kết quả
+                    if (result > 0)
+                    {
+                        return new ServiceResult(
+                            Const.SUCCESS_DELETE_CODE,
+                            Const.SUCCESS_DELETE_MSG
+                        );
+                    }
+                    else
+                    {
+                        return new ServiceResult(
+                            Const.FAIL_DELETE_CODE,
+                            Const.FAIL_DELETE_MSG
+                        );
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Trả về lỗi nếu có exception
+                return new ServiceResult(
+                    Const.ERROR_EXCEPTION,
+                    ex.ToString()
+                );
+            }
+        }
+
         public async Task<IServiceResult> SoftDeleteById(Guid managerId)
         {
             try


### PR DESCRIPTION
## 🧠 Summary

This PR implements the `DELETE` API for the `BusinessManager` module, including full service integration, controller endpoint, and robust error handling.

---

## ✨ Changes

- Add `DeleteByIdAsync` method in `BusinessManagersController`
- Implement `DeleteById` logic in `IBusinessManagerService` and its implementation
- Handle 404 (not found), 409 (conflict), and 500 (internal server error) cases
- Ensure consistency with the existing soft delete logic
- Add Vietnamese response messages for localization

---

## ✅ Checklist

- [x] Controller endpoint
- [x] Service layer
- [x] Error handling logic
- [x] Consistent response codes (`200`, `404`, `409`, `500`)
- [x] Code reviewed and tested locally

---

## 🔒 Authorization

Only users with the `Admin` role are allowed to perform this action.

---

## 📸 Screenshot / Test

```http
DELETE /api/BusinessManagers/{managerId}

Response:
- 200 OK: Xóa thành công.
- 404 Not Found: Không tìm thấy quản lý doanh nghiệp.
- 409 Conflict: Xóa thất bại.
