### PR TITLE
feat(timezone): apply Vietnam time (UTC+7) to create/update mappers and soft delete services

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/BusinessManagerMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/BusinessManagerMapper.cs
@@ -68,8 +68,8 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 ContactEmail = dto.ContactEmail,
                 BusinessLicenseUrl = dto.BusinessLicenseUrl,
                 IsCompanyVerified = false,                    // Mặc định khi đăng ký là false
-                CreatedAt = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow,
+                CreatedAt = DateHelper.NowVietnamTime(),
+                UpdatedAt = DateHelper.NowVietnamTime(),
                 IsDeleted = false
             };
         }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/RoleMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/RoleMapper.cs
@@ -2,6 +2,7 @@
 using DakLakCoffeeSupplyChain.Common.DTOs.RoleDTOs;
 using DakLakCoffeeSupplyChain.Common.Enum.ProductEnums;
 using DakLakCoffeeSupplyChain.Common.Enum.RoleEnums;
+using DakLakCoffeeSupplyChain.Common.Helpers;
 using DakLakCoffeeSupplyChain.Repositories.Models;
 using System;
 using System.Collections.Generic;
@@ -55,8 +56,8 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 RoleName = dto.RoleName,
                 Description = dto.Description,
                 Status = dto.Status.ToString(), // enum → string
-                CreatedAt = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow,
+                CreatedAt = DateHelper.NowVietnamTime(),
+                UpdatedAt = DateHelper.NowVietnamTime(),
                 IsDeleted = false
             };
         }
@@ -67,7 +68,7 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
             role.RoleName = dto.RoleName;
             role.Description = dto.Description;
             role.Status = dto.Status.ToString();  // enum → string
-            role.UpdatedAt = DateTime.UtcNow;
+            role.UpdatedAt = DateHelper.NowVietnamTime();
         }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/UserAccountMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/UserAccountMapper.cs
@@ -1,6 +1,7 @@
 ﻿using DakLakCoffeeSupplyChain.Common.DTOs.AuthDTOs;
 using DakLakCoffeeSupplyChain.Common.DTOs.UserAccountDTOs;
 using DakLakCoffeeSupplyChain.Common.Enum.UserAccountEnums;
+using DakLakCoffeeSupplyChain.Common.Helpers;
 using DakLakCoffeeSupplyChain.Repositories.Models;
 
 namespace DakLakCoffeeSupplyChain.Services.Mappers
@@ -82,8 +83,8 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 LoginType = dto.LoginType.ToString(), // enum → string
                 Status = dto.Status.ToString(),       // enum → string
                 RoleId = RoleId,
-                RegistrationDate = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow,
+                RegistrationDate = DateHelper.NowVietnamTime(),
+                UpdatedAt = DateHelper.NowVietnamTime(),
                 EmailVerified = true,         // Admin tạo thì email được xem là xác thực
                 IsVerified = true,            // Có thể xem như đã duyệt
                 VerificationCode = null,      // Không cần tạo mã xác minh
@@ -103,7 +104,7 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
             userAccount.ProfilePictureUrl = dto.ProfilePictureUrl;
             userAccount.Status = dto.Status.ToString(); // enum → string
             userAccount.RoleId = roleId;
-            userAccount.UpdatedAt = DateTime.UtcNow;
+            userAccount.UpdatedAt = DateHelper.NowVietnamTime();
         }  
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/BusinessManagerService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/BusinessManagerService.cs
@@ -12,6 +12,7 @@ using DakLakCoffeeSupplyChain.Services.Mappers;
 using DakLakCoffeeSupplyChain.Common.DTOs.BusinessManagerDTOs;
 using DakLakCoffeeSupplyChain.Services.Generators;
 using DakLakCoffeeSupplyChain.Repositories.Models;
+using DakLakCoffeeSupplyChain.Common.Helpers;
 
 namespace DakLakCoffeeSupplyChain.Services.Services
 {
@@ -336,7 +337,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 {
                     // Đánh dấu xoá mềm bằng IsDeleted
                     businessManager.IsDeleted = true;
-                    businessManager.UpdatedAt = DateTime.UtcNow;
+                    businessManager.UpdatedAt = DateHelper.NowVietnamTime();
 
                     // Cập nhật xoá mềm quản lý doanh nghiệp ở repository
                     await _unitOfWork.BusinessManagerRepository.UpdateAsync(businessManager);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProductService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProductService.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Threading.Tasks;
 using DakLakCoffeeSupplyChain.Common.DTOs.ProductDTOs;
 using Microsoft.EntityFrameworkCore;
+using DakLakCoffeeSupplyChain.Common.Helpers;
 
 namespace DakLakCoffeeSupplyChain.Services.Services
 {
@@ -176,7 +177,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 {
                     // Đánh dấu xoá mềm bằng IsDeleted
                     product.IsDeleted = true;
-                    product.UpdatedAt = DateTime.Now;
+                    product.UpdatedAt = DateHelper.NowVietnamTime();
 
                     // Cập nhật xoá mềm vai trò ở repository
                     await _unitOfWork.ProductRepository.UpdateAsync(product);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/RoleService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/RoleService.cs
@@ -1,5 +1,4 @@
-﻿using DakLakCoffeeSupplyChain.Common.DTOs.ProductDTOs;
-using DakLakCoffeeSupplyChain.Common;
+﻿using DakLakCoffeeSupplyChain.Common;
 using DakLakCoffeeSupplyChain.Repositories.UnitOfWork;
 using DakLakCoffeeSupplyChain.Services.Base;
 using DakLakCoffeeSupplyChain.Services.IServices;
@@ -11,7 +10,6 @@ using System.Threading.Tasks;
 using DakLakCoffeeSupplyChain.Common.DTOs.RoleDTOs;
 using DakLakCoffeeSupplyChain.Services.Mappers;
 using Microsoft.EntityFrameworkCore;
-using DakLakCoffeeSupplyChain.Common.DTOs.UserAccountDTOs;
 using DakLakCoffeeSupplyChain.Common.Helpers;
 using DakLakCoffeeSupplyChain.Services.Generators;
 using DakLakCoffeeSupplyChain.Common.Enum.RoleEnums;
@@ -271,7 +269,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 {
                     // Đánh dấu xoá mềm bằng IsDeleted
                     role.IsDeleted = true;
-                    role.UpdatedAt = DateTime.Now;
+                    role.UpdatedAt = DateHelper.NowVietnamTime();
 
                     // Cập nhật xoá mềm vai trò ở repository
                     await _unitOfWork.RoleRepository.UpdateAsync(role);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/UserAccountService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/UserAccountService.cs
@@ -394,7 +394,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 {
                     // Đánh dấu xoá mềm bằng IsDeleted
                     user.IsDeleted = true;
-                    user.UpdatedAt = DateTime.Now;
+                    user.UpdatedAt = DateHelper.NowVietnamTime();
 
                     // Cập nhật xoá mềm vai trò ở repository
                     await _unitOfWork.UserAccountRepository.UpdateAsync(user);


### PR DESCRIPTION
## ✨ Summary

This PR applies unified handling of Vietnam time zone (UTC+7) for `CreatedAt` and `UpdatedAt` fields in entity lifecycle operations across the system.

---

### ✅ Included changes

- Updated mappers to use `DateHelper.NowVietnamTime()`:
  - `BusinessManagerMapper` (create only)
  - `RoleMapper` (create & update)
  - `UserAccountMapper` (create & update)

- Updated soft delete logic to record `UpdatedAt` in Vietnam time for:
  - `BusinessManagerService`
  - `RoleService`
  - `UserAccountService`
  - `ProductService`

---

### 📂 Affected files

- `BusinessManagerMapper.cs`
- `RoleMapper.cs`
- `UserAccountMapper.cs`
- `BusinessManagerService.cs`
- `RoleService.cs`
- `UserAccountService.cs`
- `ProductService.cs`

---

### 📌 Notes

- Uses Windows timezone ID: `"SE Asia Standard Time"`
- Timestamp updates now reflect local business context (Vietnam)
- Future support for dynamic `TimeZoneId` per user could be considered

---

✅ Ready for review & merge.
