### PR TITLE
feat(cropseason): implement soft delete logic and endpoint

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropSeasonController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropSeasonController.cs
@@ -101,5 +101,22 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             return StatusCode(500, result.Message);
         }
+
+        [HttpPatch("soft-delete/{cropSeasonId}")]
+        [Authorize(Roles = "Admin,BusinessManager")]
+        public async Task<IActionResult> SoftDeleteCropSeason(Guid cropSeasonId)
+        {
+            var result = await _cropSeasonService.SoftDeleteAsync(cropSeasonId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok(result.Message);
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound(result.Message);
+
+            return StatusCode(500, result.Message);
+        }
+
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropSeasonRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropSeasonRepository.cs
@@ -18,6 +18,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
         Task DeleteCropSeasonDetailsBySeasonIdAsync(Guid cropSeasonId);
 
         Task<bool> ExistsAsync(Expression<Func<CropSeason, bool>> predicate);
+        void SoftDelete(CropSeason entity);
 
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonRepository.cs
@@ -14,20 +14,23 @@ public class CropSeasonRepository : GenericRepository<CropSeason>, ICropSeasonRe
     {
         return await _context.CropSeasons
             .AsNoTracking()
+            .Where(c => !c.IsDeleted) 
             .Include(c => c.Farmer)
                 .ThenInclude(f => f.User)
             .OrderBy(c => c.StartDate)
             .ToListAsync();
     }
 
+
     public async Task<CropSeason?> GetCropSeasonByIdAsync(Guid cropSeasonId)
     {
         return await _context.CropSeasons
             .AsNoTracking()
             .Include(c => c.Farmer)
-              .ThenInclude(f => f.User)
-            .FirstOrDefaultAsync(c => c.CropSeasonId == cropSeasonId);
+                .ThenInclude(f => f.User)
+            .FirstOrDefaultAsync(c => c.CropSeasonId == cropSeasonId && !c.IsDeleted);
     }
+
     public async Task<int> CountByYearAsync(int year)
     {
         return await _context.CropSeasons
@@ -37,8 +40,9 @@ public class CropSeasonRepository : GenericRepository<CropSeason>, ICropSeasonRe
     {
         return await _context.CropSeasons
             .Include(cs => cs.CropSeasonDetails)
-            .FirstOrDefaultAsync(cs => cs.CropSeasonId == cropSeasonId);
+            .FirstOrDefaultAsync(cs => cs.CropSeasonId == cropSeasonId && !cs.IsDeleted);
     }
+
 
     public async Task DeleteCropSeasonDetailsBySeasonIdAsync(Guid cropSeasonId)
     {
@@ -51,6 +55,12 @@ public class CropSeasonRepository : GenericRepository<CropSeason>, ICropSeasonRe
     public async Task<bool> ExistsAsync(Expression<Func<CropSeason, bool>> predicate)
     {
         return await _context.CropSeasons.AnyAsync(predicate);
+    }
+
+    public void SoftDelete(CropSeason entity)
+    {
+        entity.IsDeleted = true;
+        _context.CropSeasons.Update(entity);
     }
 
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropSeasonService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropSeasonService.cs
@@ -14,5 +14,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> Update(CropSeasonUpdateDto dto);
 
         Task<IServiceResult> DeleteById(Guid cropSeasonId);
+
+        Task<IServiceResult> SoftDeleteAsync(Guid cropSeasonId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropSeasonService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropSeasonService.cs
@@ -196,5 +196,18 @@ namespace DakLakCoffeeSupplyChain.Services.Services
 
             return new ServiceResult(Const.SUCCESS_DELETE_CODE, "Xóa mùa vụ thành công.");
         }
+
+        public async Task<IServiceResult> SoftDeleteAsync(Guid cropSeasonId)
+        {
+            var existing = await _unitOfWork.CropSeasonRepository.GetByIdAsync(cropSeasonId);
+            if (existing == null || existing.IsDeleted)
+                return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Không tìm thấy hoặc mùa vụ đã bị xoá.");
+
+            _unitOfWork.CropSeasonRepository.SoftDelete(existing);
+            await _unitOfWork.SaveChangesAsync();
+
+            return new ServiceResult(Const.SUCCESS_DELETE_CODE, "Xoá mềm mùa vụ thành công.");
+        }
+
     }
 }


### PR DESCRIPTION
## 📌 Summary

Implemented soft delete for the `CropSeason` module using `IsDeleted` flag.

---

## ✅ Changes

- Added `IsDeleted` property to `CropSeason` entity
- Updated `CropSeasonRepository`:
  - `GetAllCropSeasonsAsync`, `GetById`, `GetWithDetailsById` now exclude soft-deleted records
  - Added `SoftDelete()` method
- Extended `ICropSeasonRepository` with `SoftDelete(CropSeason entity)`
- Implemented `SoftDeleteAsync(Guid)` in `CropSeasonService`
- Declared `SoftDeleteAsync` in `ICropSeasonService`
- Created PATCH endpoint:
