### PR TITLE
feat(business-buyer): implement GetAll API with DTO, service, repository, and OData filtering

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessBuyersController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessBuyersController.cs
@@ -1,0 +1,44 @@
+﻿using DakLakCoffeeSupplyChain.Common;
+using DakLakCoffeeSupplyChain.Services.IServices;
+using DakLakCoffeeSupplyChain.Services.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Query;
+using System.Security.Claims;
+
+// For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
+
+namespace DakLakCoffeeSupplyChain.APIService.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class BusinessBuyersController : ControllerBase
+    {
+        private readonly IBusinessBuyerService _businessBuyerService;
+
+        public BusinessBuyersController(IBusinessBuyerService businessBuyerService)
+            => _businessBuyerService = businessBuyerService;
+
+        // GET: api/<BusinessBuyersController>
+        [HttpGet]
+        [EnableQuery]
+        [Authorize(Roles = "BusinessManager")]
+        public async Task<IActionResult> GetAllBussinessBuyersAsync()
+        {
+            var userIdStr = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            if (!Guid.TryParse(userIdStr, out var userId))
+                return Unauthorized("Không xác định được UserId từ token.");
+
+            var result = await _businessBuyerService.GetAll(userId);
+
+            if (result.Status == Const.SUCCESS_READ_CODE)
+                return Ok(result.Data);              // Trả đúng dữ liệu
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound(result.Message);     // Trả 404 + message
+
+            return StatusCode(500, result.Message);  // Trả 500 + message
+        }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Program.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Program.cs
@@ -34,6 +34,7 @@ builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 builder.Services.AddScoped<IRoleService, RoleService>();
 builder.Services.AddScoped<IUserAccountService, UserAccountService>();
 builder.Services.AddScoped<IBusinessManagerService, BusinessManagerService>();
+builder.Services.AddScoped<IBusinessBuyerService, BusinessBuyerService>();
 builder.Services.AddScoped<IContractService, ContractService>();
 builder.Services.AddScoped<ICropSeasonService, CropSeasonService>();
 builder.Services.AddScoped<ICropStageService, CropStageService>();
@@ -79,6 +80,7 @@ static IEdmModel GetEdmModel()
     odataBuilder.EntitySet<Role>("Role");
     odataBuilder.EntitySet<UserAccount>("UserAccount");
     odataBuilder.EntitySet<BusinessManager>("BusinessManager");
+    odataBuilder.EntitySet<BusinessBuyer>("BusinessBuyer");
     odataBuilder.EntitySet<Contract>("Contract");
     odataBuilder.EntitySet<ProcurementPlan>("ProcurementPlan");
     odataBuilder.EntitySet<CropStage>("CropStage");
@@ -87,7 +89,6 @@ static IEdmModel GetEdmModel()
     odataBuilder.EntitySet<ProcessingMethod>("ProcessingMethod");
     odataBuilder.EntitySet<WarehouseInboundRequest>("WarehouseInboundRequest");
     odataBuilder.EntitySet<Product>("Product");
-
 
     return odataBuilder.GetEdmModel();
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/BusinessBuyerDTOs/BusinessBuyerViewAllDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/BusinessBuyerDTOs/BusinessBuyerViewAllDto.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.BusinessBuyerDTOs
+{
+    public class BusinessBuyerViewAllDto
+    {
+        public Guid BuyerId { get; set; }
+
+        public string BuyerCode { get; set; } = string.Empty;
+
+        public string CompanyName { get; set; } = string.Empty;
+
+        public string ContactPerson { get; set; } = string.Empty;
+
+        public string Position { get; set; } = string.Empty;
+
+        public string CompanyAddress { get; set; } = string.Empty;
+
+        public DateTime CreatedAt { get; set; }
+
+        public string CreatedByName { get; set; } = string.Empty;
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IBusinessBuyerRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IBusinessBuyerRepository.cs
@@ -1,0 +1,14 @@
+﻿using DakLakCoffeeSupplyChain.Repositories.Base;
+using DakLakCoffeeSupplyChain.Repositories.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
+{
+    public interface IBusinessBuyerRepository : IGenericRepository<BusinessBuyer>
+    {
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Models/BusinessBuyer.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Models/BusinessBuyer.cs
@@ -2,11 +2,13 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace DakLakCoffeeSupplyChain.Repositories.Models;
 
 public partial class BusinessBuyer
 {
+    [Key]
     public Guid BuyerId { get; set; }
 
     public string BuyerCode { get; set; }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/BusinessBuyerRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/BusinessBuyerRepository.cs
@@ -1,0 +1,20 @@
+﻿using DakLakCoffeeSupplyChain.Repositories.Base;
+using DakLakCoffeeSupplyChain.Repositories.DBContext;
+using DakLakCoffeeSupplyChain.Repositories.IRepositories;
+using DakLakCoffeeSupplyChain.Repositories.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Repositories.Repositories
+{
+    public class BusinessBuyerRepository : GenericRepository<BusinessBuyer>, IBusinessBuyerRepository
+    {
+        public BusinessBuyerRepository() { }
+
+        public BusinessBuyerRepository(DakLakCoffee_SCMContext context)
+            => _context = context;
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/IUnitOfWork.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/IUnitOfWork.cs
@@ -19,6 +19,8 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
 
         IFarmerRepository FarmerRepository { get; }
 
+        IBusinessBuyerRepository BusinessBuyerRepository { get; }
+
         IContractRepository ContractRepository { get; }
 
         IProcurementPlanRepository ProcurementPlanRepository { get; }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/UnitOfWork.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/UnitOfWork.cs
@@ -14,6 +14,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
         private IRoleRepository? roleRepository;
         private IUserAccountRepository? userAccountRepository;
         private IBusinessManagerRepository? businessManagerRepository;
+        private IBusinessBuyerRepository? businessBuyerRepository;
         private IContractRepository? contractRepository;
         private IProductRepository? productRepository;
         private ISystemConfigurationRepository? systemConfigurationRepository;
@@ -63,6 +64,14 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
             get
             {
                 return businessManagerRepository ??= new BusinessManagerRepository(context);
+            }
+        }
+
+        public IBusinessBuyerRepository BusinessBuyerRepository
+        {
+            get
+            {
+                return businessBuyerRepository ??= new BusinessBuyerRepository(context);
             }
         }
 

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessBuyerService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessBuyerService.cs
@@ -1,0 +1,14 @@
+﻿using DakLakCoffeeSupplyChain.Services.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Services.IServices
+{
+    public interface IBusinessBuyerService
+    {
+        Task<IServiceResult> GetAll(Guid userId);
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/BusinessBuyerMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/BusinessBuyerMapper.cs
@@ -1,0 +1,29 @@
+﻿using DakLakCoffeeSupplyChain.Common.DTOs.BusinessBuyerDTOs;
+using DakLakCoffeeSupplyChain.Repositories.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Services.Mappers
+{
+    public static class BusinessBuyerMapper
+    {
+        // Mapper BusinessManagerViewAllDto
+        public static BusinessBuyerViewAllDto MapToBusinessBuyerViewAllDto(this BusinessBuyer businessBuyer)
+        {
+            return new BusinessBuyerViewAllDto
+            {
+                BuyerId = businessBuyer.BuyerId,
+                BuyerCode = businessBuyer.BuyerCode ?? string.Empty,
+                CompanyName = businessBuyer.CompanyName ?? string.Empty,
+                ContactPerson = businessBuyer.ContactPerson ?? string.Empty,
+                Position = businessBuyer.Position ?? string.Empty,
+                CompanyAddress = businessBuyer.CompanyAddress ?? string.Empty,
+                CreatedAt = businessBuyer.CreatedAt,
+                CreatedByName = businessBuyer.CreatedByNavigation?.CompanyName ?? string.Empty
+            };
+        }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/BusinessBuyerService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/BusinessBuyerService.cs
@@ -1,0 +1,76 @@
+﻿using DakLakCoffeeSupplyChain.Common.DTOs.BusinessManagerDTOs;
+using DakLakCoffeeSupplyChain.Common;
+using DakLakCoffeeSupplyChain.Repositories.UnitOfWork;
+using DakLakCoffeeSupplyChain.Services.Base;
+using DakLakCoffeeSupplyChain.Services.Generators;
+using DakLakCoffeeSupplyChain.Services.IServices;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DakLakCoffeeSupplyChain.Common.DTOs.BusinessBuyerDTOs;
+using DakLakCoffeeSupplyChain.Services.Mappers;
+
+namespace DakLakCoffeeSupplyChain.Services.Services
+{
+    public class BusinessBuyerService : IBusinessBuyerService
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public BusinessBuyerService(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork
+                ?? throw new ArgumentNullException(nameof(unitOfWork));
+        }
+
+        public async Task<IServiceResult> GetAll(Guid userId)
+        {
+            var manager = await _unitOfWork.BusinessManagerRepository.GetByIdAsync(
+                predicate: m => m.UserId == userId,
+                asNoTracking: true
+            );
+
+            if (manager == null)
+            {
+                return new ServiceResult(
+                    Const.WARNING_NO_DATA_CODE,
+                    "Không tìm thấy BusinessManager tương ứng với tài khoản."
+                );
+            }
+
+            // Lấy danh sách buyer từ repository
+            var businessBuyers = await _unitOfWork.BusinessBuyerRepository.GetAllAsync(
+                predicate: bb => bb.IsDeleted != true && bb.CreatedBy == manager.ManagerId,
+                include: query => query
+                   .Include(bb => bb.CreatedByNavigation),
+                orderBy: query => query.OrderBy(bb => bb.BuyerCode),
+                asNoTracking: true
+            );
+
+            // Kiểm tra nếu không có dữ liệu
+            if (businessBuyers == null || !businessBuyers.Any())
+            {
+                return new ServiceResult(
+                    Const.WARNING_NO_DATA_CODE,
+                    Const.WARNING_NO_DATA_MSG,
+                    new List<BusinessBuyerViewAllDto>()  // Trả về danh sách rỗng
+                );
+            }
+            else
+            {
+                // Chuyển đổi sang danh sách DTO để trả về cho client
+                var businessBuyerDtos = businessBuyers
+                    .Select(businessBuyers => businessBuyers.MapToBusinessBuyerViewAllDto())
+                    .ToList();
+
+                return new ServiceResult(
+                    Const.SUCCESS_READ_CODE,
+                    Const.SUCCESS_READ_MSG,
+                    businessBuyerDtos
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
### ✅ Summary

Implemented `GetAll` API for `BusinessBuyer` with full support for:

- 🎯 Role-based authorization (`BusinessManager` only)
- 📦 Repository and service layer separation
- 🔎 OData filtering via `[EnableQuery]`
- ❌ Soft delete filtering (`IsDeleted == false`)
- 🔐 User scoping via `CreatedBy == currentManagerId`

---

### 🚀 What’s Included?

- New Controller: `BusinessBuyersController`
- New DTO: `BusinessBuyerViewAllDto`
- New Service: `BusinessBuyerService` + interface
- New Repository: `BusinessBuyerRepository` + interface
- Mapper: `MapToBusinessBuyerViewAllDto()`
- Logic to extract `UserId` from JWT and resolve to `ManagerId`

---

### 📌 Design Notes

- Each `BusinessBuyer` is scoped to its creator (`CreatedBy == ManagerId`)
- JWT must contain `ClaimTypes.NameIdentifier` → mapped to `UserId`
- Only 1 manager per business is assumed → no `CompanyId` needed

---

### 🧪 Tested

- ✅ Auth required (`401` if missing or invalid token)
- ✅ Manager without any buyer gets empty list (`404`)
- ✅ Manager only sees buyers created by themselves
- ✅ OData filter like `$filter=contains(CompanyName,'Coffee')` works

---

### 📎 Related

- No breaking changes
- Ready for merge into `main`

