### PR TITLE
feat(cropstage): implement full create, update, and hard delete featu…

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropStagesController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropStagesController.cs
@@ -37,30 +37,30 @@ public class CropStagesController : ControllerBase
         var result = await _cropStageService.GetById(stageId);
 
         if (result.Status == Const.SUCCESS_READ_CODE)
-            return Ok(result.Data);            
+            return Ok(result.Data);
 
         if (result.Status == Const.WARNING_NO_DATA_CODE)
-            return NotFound(result.Message);    
+            return NotFound(result.Message);
 
-        return StatusCode(500, result.Message);  
+        return StatusCode(500, result.Message);
     }
 
-        [HttpPost]
-        public async Task<IActionResult> CreateCropStage([FromBody] CropStageCreateDto dto)
-        {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
+    [HttpPost]
+    public async Task<IActionResult> CreateCropStage([FromBody] CropStageCreateDto dto)
+    {
+        if (!ModelState.IsValid)
+            return BadRequest(ModelState);
 
-            var result = await _cropStageService.Create(dto);
+        var result = await _cropStageService.Create(dto);
 
-            if (result.Status == Const.SUCCESS_CREATE_CODE)
-                return Ok(result.Data);
+        if (result.Status == Const.SUCCESS_CREATE_CODE)
+            return Ok(result.Data);
 
-            if (result.Status == Const.FAIL_CREATE_CODE)
-                return Conflict(result.Message);
+        if (result.Status == Const.FAIL_CREATE_CODE)
+            return Conflict(result.Message);
 
-            return StatusCode(500, result.Message);
-        }
+        return StatusCode(500, result.Message);
+    }
 
     [HttpPut("{stageId}")]
     public async Task<IActionResult> UpdateCropStage(int stageId, [FromBody] CropStageUpdateDto dto)
@@ -78,6 +78,20 @@ public class CropStagesController : ControllerBase
 
         if (result.Status == Const.FAIL_UPDATE_CODE)
             return Conflict(result.Message);
+
+        if (result.Status == Const.WARNING_NO_DATA_CODE)
+            return NotFound(result.Message);
+
+        return StatusCode(500, result.Message);
+    }
+
+    [HttpDelete("{stageId}")]
+    public async Task<IActionResult> DeleteCropStage(int stageId)
+    {
+        var result = await _cropStageService.Delete(stageId);
+
+        if (result.Status == Const.SUCCESS_DELETE_CODE)
+            return Ok(result.Message);
 
         if (result.Status == Const.WARNING_NO_DATA_CODE)
             return NotFound(result.Message);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropStageRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropStageRepository.cs
@@ -10,5 +10,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
         Task<List<CropStage>> GetAllOrderedAsync();
         Task<CropStage?> GetByIdAsync(int stageId);
 
+        Task DeleteCropCropStageByStageIdAsync(int stageId);
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropStageRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropStageRepository.cs
@@ -35,5 +35,14 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
                 .FirstOrDefaultAsync(cs => cs.StageId == stageId);
         }
 
+        public async Task DeleteCropCropStageByStageIdAsync(int stageId)
+        {
+            var entity = await _context.CropStages.FindAsync(stageId);
+            if (entity != null)
+            {
+                _context.CropStages.Remove(entity);
+            }
+        }
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropStageService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropStageService.cs
@@ -15,5 +15,8 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Update(CropStageUpdateDto dto);
 
+        Task<IServiceResult> Delete(int stageId);
+
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropStageService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropStageService.cs
@@ -164,5 +164,29 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 return new ServiceResult(Const.ERROR_EXCEPTION, ex.ToString());
             }
         }
+
+        public async Task<IServiceResult> Delete(int stageId)
+        {
+            try
+            {
+                var stage = await _unitOfWork.CropStageRepository.GetByIdAsync(stageId);
+
+                if (stage == null)
+                    return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Giai đoạn không tồn tại hoặc đã bị xóa.");
+
+                await _unitOfWork.CropStageRepository.DeleteCropCropStageByStageIdAsync(stageId);
+
+                var result = await _unitOfWork.SaveChangesAsync();
+
+                if (result > 0)
+                    return new ServiceResult(Const.SUCCESS_DELETE_CODE, Const.SUCCESS_DELETE_MSG);
+
+                return new ServiceResult(Const.FAIL_DELETE_CODE, Const.FAIL_DELETE_MSG);
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult(Const.ERROR_EXCEPTION, ex.ToString());
+            }
+        }
     }
 }


### PR DESCRIPTION
### 🌱 Chức năng: Quản lý danh mục giai đoạn mùa vụ (CropStage)

#### ✅ Mục tiêu
Triển khai đầy đủ chức năng CRUD (trừ ReadAll đã có):  
- Tạo mới (Create)
- Cập nhật (Update)
- Xóa cứng (Hard Delete) theo `StageId` (kiểu Guid)

---

#### 🔧 Chi tiết kỹ thuật đã thực hiện

##### DTO
- `CropStageCreateDto`: Dùng để tạo mới. Có validation `[Required]`, `[StringLength]`, `[Range]`
- `CropStageUpdateDto`: Có thêm `StageId (Guid)` để hỗ trợ cập nhật

##### Mapper
- `MapToNewCropStage`: Từ DTO sang Entity mới
- `MapToUpdateCropStage`: Gán lại thông tin khi cập nhật

##### Service
- `Create(dto)`:
  - Kiểm tra trùng `StageCode`, `StageName`, `OrderIndex`
- `Update(dto)`:
  - Kiểm tra tồn tại và trùng thông tin ngoại trừ chính nó
- `Delete(Guid stageId)`:
  - Gọi `DeleteAsync(stage)` từ repository, xóa khỏi DB

##### Controller
- `[HttpPost]`: `/api/CropStages`
- `[HttpPut("{stageId}")]`: cập nhật theo ID
- `[HttpDelete("{stageId}")]`: xóa theo `Guid`

---

#### 🔐 Quy tắc xử lý lỗi
| Trường hợp                        | HTTP Code | Message                                 |
|----------------------------------|-----------|------------------------------------------|
| Tạo trùng mã/tên/thứ tự          | 409       | Mã/Tên/Thứ tự giai đoạn đã tồn tại       |
| Cập nhật ID không tồn tại        | 404       | Giai đoạn không tồn tại hoặc đã bị xóa   |
| Xóa sai `Guid` hoặc không tồn tại| 404       | Giai đoạn không tồn tại hoặc đã bị xóa   |
| Dữ liệu đầu vào sai              | 400       | ModelState errors                        |
| Thành công                       | 200       | Trả về dữ liệu hoặc message thành công   |

---

#### 🧪 Swagger Test Sample

```http
DELETE /api/CropStages/6f9619ff-8b86-d011-b42d-00cf4fc964ff
