### PR TITLE
feat(cropstage): implement soft delete functionality using stageId (G…

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropStagesController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropStagesController.cs
@@ -98,4 +98,19 @@ public class CropStagesController : ControllerBase
 
         return StatusCode(500, result.Message);
     }
+
+    [HttpPatch("{stageId}/soft-delete")]
+    public async Task<IActionResult> SoftDeleteCropStage(int stageId)
+    {
+        var result = await _cropStageService.SoftDelete(stageId);
+
+        if (result.Status == Const.SUCCESS_DELETE_CODE)
+            return Ok(result.Message);
+
+        if (result.Status == Const.WARNING_NO_DATA_CODE)
+            return NotFound(result.Message);
+
+        return StatusCode(500, result.Message);
+    }
+
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropStageService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropStageService.cs
@@ -17,6 +17,8 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Delete(int stageId);
 
+        Task<IServiceResult> SoftDelete(int stageId);
+
 
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropStageService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropStageService.cs
@@ -179,14 +179,41 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 var result = await _unitOfWork.SaveChangesAsync();
 
                 if (result > 0)
-                    return new ServiceResult(Const.SUCCESS_DELETE_CODE, Const.SUCCESS_DELETE_MSG);
+                    return new ServiceResult(Const.SUCCESS_DELETE_CODE, "Xóa stage giai đoạn thành công.");
 
-                return new ServiceResult(Const.FAIL_DELETE_CODE, Const.FAIL_DELETE_MSG);
+                return new ServiceResult(Const.FAIL_DELETE_CODE, "Xóa stage thất bại.");
             }
             catch (Exception ex)
             {
                 return new ServiceResult(Const.ERROR_EXCEPTION, ex.ToString());
             }
         }
+
+        public async Task<IServiceResult> SoftDelete(int stageId)
+        {
+            try
+            {
+                var stage = await _unitOfWork.CropStageRepository.GetByIdAsync(stageId);
+
+                if (stage == null || stage.IsDeleted)
+                    return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Giai đoạn không tồn tại hoặc đã bị xóa.");
+
+                stage.IsDeleted = true;
+                stage.UpdatedAt = DateTime.UtcNow;
+
+                await _unitOfWork.CropStageRepository.UpdateAsync(stage);
+                var result = await _unitOfWork.SaveChangesAsync();
+
+                if (result > 0)
+                    return new ServiceResult(Const.SUCCESS_DELETE_CODE, "Xóa mềm giai đoạn thành công.");
+
+                return new ServiceResult(Const.FAIL_DELETE_CODE, "Xóa mềm thất bại.");
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult(Const.ERROR_EXCEPTION, ex.ToString());
+            }
+        }
+
     }
 }


### PR DESCRIPTION
### 🧩 Chức năng: Xóa mềm giai đoạn mùa vụ (CropStage)

#### ✅ Mục tiêu
- Cho phép xóa mềm giai đoạn mùa vụ thay vì xóa cứng khỏi cơ sở dữ liệu.
- Giai đoạn bị xóa sẽ được đánh dấu `IsDeleted = true` và không hiển thị trong danh sách `GetAll`.

---

#### 🔧 Chi tiết kỹ thuật

##### Service
- Thêm method `SoftDelete(Guid stageId)` trong `ICropStageService` và `CropStageService`.
- Kiểm tra tồn tại và chưa bị xóa (`!IsDeleted`) trước khi xử lý.
- Gán `IsDeleted = true` và cập nhật `UpdatedAt`.

##### Controller
- Thêm route:
  ```csharp
  [HttpPatch("soft-delete/{stageId}")]
  public async Task<IActionResult> SoftDeleteCropStage(Guid stageId)
