### PR TITLE
feat(cropstage): apply role-based authorization to CropStagesControll…

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropStagesController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropStagesController.cs
@@ -2,11 +2,13 @@
 using DakLakCoffeeSupplyChain.Common.DTOs.CropStageDTOs;
 using DakLakCoffeeSupplyChain.Services.IServices;
 using DakLakCoffeeSupplyChain.Services.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Query;
 
 [Route("api/[controller]")]
 [ApiController]
+[Authorize]
 public class CropStagesController : ControllerBase
 {
     private readonly ICropStageService _cropStageService;
@@ -46,6 +48,8 @@ public class CropStagesController : ControllerBase
     }
 
     [HttpPost]
+    [Authorize(Roles = "Admin,AgriculturalExpert")]
+
     public async Task<IActionResult> CreateCropStage([FromBody] CropStageCreateDto dto)
     {
         if (!ModelState.IsValid)
@@ -63,6 +67,7 @@ public class CropStagesController : ControllerBase
     }
 
     [HttpPut("{stageId}")]
+    [Authorize(Roles = "Admin,AgriculturalExpert")]
     public async Task<IActionResult> UpdateCropStage(int stageId, [FromBody] CropStageUpdateDto dto)
     {
         if (stageId != dto.StageId)
@@ -86,6 +91,7 @@ public class CropStagesController : ControllerBase
     }
 
     [HttpDelete("{stageId}")]
+    [Authorize(Roles = "Admin")]
     public async Task<IActionResult> DeleteCropStage(int stageId)
     {
         var result = await _cropStageService.Delete(stageId);
@@ -100,6 +106,7 @@ public class CropStagesController : ControllerBase
     }
 
     [HttpPatch("{stageId}/soft-delete")]
+    [Authorize(Roles = "Admin,BusinessManager")]
     public async Task<IActionResult> SoftDeleteCropStage(int stageId)
     {
         var result = await _cropStageService.SoftDelete(stageId);


### PR DESCRIPTION
### 🔐 Phân quyền theo vai trò: CropStagesController

#### ✅ Mục tiêu
Bảo vệ các endpoint theo vai trò người dùng, đảm bảo chỉ những người có quyền hợp lệ mới được thực hiện hành động cụ thể.

---

#### 🔧 Cập nhật

- Áp dụng `[Authorize]` cho toàn bộ controller → yêu cầu người dùng đã đăng nhập.
- Gán quyền cụ thể cho từng endpoint:

| Endpoint                       | HTTP Verb | Vai trò cho phép                         |
|--------------------------------|-----------|------------------------------------------|
| `/api/CropStages`              | GET       | ✅ Tất cả người dùng đã đăng nhập         |
| `/api/CropStages/{id}`         | GET       | ✅ Tất cả người dùng đã đăng nhập         |
| `/api/CropStages`              | POST      | `Admin`, `AgriculturalExpert`            |
| `/api/CropStages/{id}`         | PUT       | `Admin`, `AgriculturalExpert`            |
| `/api/CropStages/{id}`         | DELETE    | `Admin`                                   |
| `/api/CropStages/soft-delete/{id}` | PATCH | `Admin`, `BusinessManager`               |

---

#### 🛠 Kỹ thuật
- Sử dụng `[Authorize(Roles = "...")]` từ namespace `Microsoft.AspNetCore.Authorization`.
- Các role phải khớp với giá trị claim `role` trong JWT/token xác thực.

---

#### 🔐 Lợi ích
- Bảo mật tốt hơn: chỉ người được phân quyền mới có thể thao tác dữ liệu quan trọng.
- Đáp ứng yêu cầu phân quyền theo nghiệp vụ: ví dụ, `BusinessManager` không được xóa cứng, nhưng được xóa mềm.

---

✅ Đảm bảo tính bảo mật và phân tầng quyền truy cập phù hợp cho hệ thống quản lý mùa vụ.
