### PR TITLE
feat(procurementPlan) Implement Create procurement plan API

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcurementPlansController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcurementPlansController.cs
@@ -1,4 +1,6 @@
 ﻿using DakLakCoffeeSupplyChain.Common;
+using DakLakCoffeeSupplyChain.Common.DTOs.ProcurementPlanDTOs;
+using DakLakCoffeeSupplyChain.Common.DTOs.UserAccountDTOs;
 using DakLakCoffeeSupplyChain.Services.IServices;
 using DakLakCoffeeSupplyChain.Services.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -114,6 +116,27 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             if (result.Status == Const.FAIL_DELETE_CODE)
                 return Conflict("Xóa mềm thất bại.");
+
+            return StatusCode(500, result.Message);
+        }
+
+        // POST api/<ProcurementPlan>
+        [HttpPost]
+        [Authorize(Roles = "BusinessManager")]
+        public async Task<IActionResult> CreateProcurementPlanAsync([FromBody] ProcurementPlanCreateDto planDto)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var result = await _procurementPlanService.Create(planDto);
+
+            if (result.Status == Const.SUCCESS_CREATE_CODE)
+                return CreatedAtAction(nameof(GetById),
+                    new { planId = ((ProcurementPlanViewDetailsSumaryDto)result.Data).PlanId },
+                    result.Data);
+
+            if (result.Status == Const.FAIL_CREATE_CODE)
+                return Conflict(result.Message);
 
             return StatusCode(500, result.Message);
         }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Program.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Program.cs
@@ -26,6 +26,7 @@ builder.Services.AddScoped<IPasswordHasher, PasswordHasher>();
 // Đăng ký service tạo mã định danh
 builder.Services.AddScoped<ICodeGenerator, CodeGenerator>();
 builder.Services.AddScoped<ICropSeasonCodeGenerator, CropSeasonCodeGenerator>();
+builder.Services.AddScoped<IProcurementPlanCodeGenerator, ProcurementPlanCodeGenerator>();
 
 // Unit of Work pattern: quản lý Transaction + Repository access
 builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcurementPlanDTOs/ProcurementPlanCreateDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcurementPlanDTOs/ProcurementPlanCreateDto.cs
@@ -1,17 +1,17 @@
-﻿using DakLakCoffeeSupplyChain.Common.Enum.ProcurementPlanEnums;
+﻿using DakLakCoffeeSupplyChain.Common.DTOs.ProcurementPlanDTOs.ViewDetailsDtos;
+using DakLakCoffeeSupplyChain.Common.Enum.ProcurementPlanEnums;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace DakLakCoffeeSupplyChain.Common.DTOs.ProcurementPlanDTOs
 {
-    public class ProcurementPlanCreateDto
+    public class ProcurementPlanCreateDto : IValidatableObject
     {
         [Required(ErrorMessage = "Tên kế hoạch không được để trống.")]
         public string Title { get; set; } = string.Empty;
         [Required(ErrorMessage = "Mô tả không được để trống.")]
         public string Description { get; set; } = string.Empty;
-        [Required(ErrorMessage = "Ngày bắt đầu nhận đăng ký không được để trống.")]
-        public DateOnly StartDate { get; set; }
+        public DateOnly? StartDate { get; set; }
         [Required(ErrorMessage = "Ngày kết thúc nhận đăng ký không được để trống.")]
         public DateOnly EndDate { get; set; }
         [Required(ErrorMessage = "Chưa đăng nhập")]
@@ -19,5 +19,36 @@ namespace DakLakCoffeeSupplyChain.Common.DTOs.ProcurementPlanDTOs
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public ProcurementPlanStatus Status { get; set; } = ProcurementPlanStatus.Draft;
 
+        public ICollection<ProcurementPlanDetailsCreateDto> ProcurementPlansDetails { get; set; } = [];
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            // Kiểm tra có tồn tại detail không
+            if (ProcurementPlansDetails == null || ProcurementPlansDetails.Count == 0)
+                yield return new ValidationResult(
+                        "Phải có ít nhất một chi tiết kế hoạch thu mua",
+                        [nameof(ProcurementPlansDetails)]);
+
+            var today = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+
+            // Nếu có StartDate → không được trong quá khứ
+            if (StartDate.HasValue && StartDate.Value < today)
+                yield return new ValidationResult(
+                        "Ngày bắt đầu không được ở trong quá khứ",
+                        [nameof(StartDate)]);
+
+            // EndDate luôn required → check ngày quá khứ
+            if (EndDate < today)
+                yield return new ValidationResult(
+                        "Ngày kết thúc không được ở trong quá khứ",
+                        [nameof(EndDate)]);
+
+            // Nếu trạng thái là DRAFT và StartDate có giá trị → so sánh logic
+            if (Status == ProcurementPlanStatus.Draft && StartDate.HasValue)
+                if (StartDate.Value > EndDate)
+                    yield return new ValidationResult(
+                            "Ngày bắt đầu không thể sau ngày kết thúc",
+                            [nameof(StartDate), nameof(EndDate)]);
+        }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcurementPlanDTOs/ProcurementPlanViewDetailsSumaryDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcurementPlanDTOs/ProcurementPlanViewDetailsSumaryDto.cs
@@ -12,6 +12,7 @@ namespace DakLakCoffeeSupplyChain.Common.DTOs.ProcurementPlanDTOs
         public string Title { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
         public double? TotalQuantity { get; set; }
+        public Guid CreatedById { get; set; }
         public BusinessManagerSummaryDto? CreatedBy { get; set; }
         public DateOnly? StartDate { get; set; }
         public DateOnly? EndDate { get; set; }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcurementPlanDTOs/ViewDetailsDtos/ProcurementPlanDetailsCreateDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcurementPlanDTOs/ViewDetailsDtos/ProcurementPlanDetailsCreateDto.cs
@@ -1,0 +1,44 @@
+﻿using DakLakCoffeeSupplyChain.Common.Enum.ProcurementPlanEnums;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.ProcurementPlanDTOs.ViewDetailsDtos
+{
+    public class ProcurementPlanDetailsCreateDto : IValidatableObject
+    {
+        [Required(ErrorMessage = "Loại cà phê không được để trống.")]
+        public Guid CoffeeType { get; set; }
+
+        [Required(ErrorMessage = "Sản lượng mong muốn không được để trống.")]
+        public double TargetQuantity { get; set; }
+        public string? TargetRegion { get; set; }
+
+        [Required(ErrorMessage = "Sản lượng tối thiểu không được để trống.")]
+        [Range(100, double.MaxValue, ErrorMessage = "Sản lượng tối thiểu phải từ 100kg trở lên.")]
+        public double MinimumRegistrationQuantity { get; set; }
+
+        [Required(ErrorMessage = "Giá thương lượng tối thiểu không được để trống.")]
+        public double MinPriceRange { get; set; }
+
+        [Required(ErrorMessage = "Giá thương lượng tối đa không được để trống.")]
+        public double MaxPriceRange { get; set; }
+
+        public string Note { get; set; } = string.Empty;
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public ProcurementPlanDetailsStatus Status { get; set; } = ProcurementPlanDetailsStatus.Disable;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (MinimumRegistrationQuantity > TargetQuantity)
+                yield return new ValidationResult(
+                        "Sản lượng tối thiểu không thể lớn hơn sản lượng mong muốn",
+                        [nameof(MinimumRegistrationQuantity)]);
+
+            if (MinPriceRange > MaxPriceRange)
+                yield return new ValidationResult(
+                        "Số tiền thương lượng tối thiểu không thể lớn hơn số tiền thương lượng tối đa",
+                        [nameof(MinPriceRange)]);
+        }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IProcurementPlanDetailsRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IProcurementPlanDetailsRepository.cs
@@ -5,5 +5,6 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
 {
     public interface IProcurementPlanDetailsRepository : IGenericRepository<ProcurementPlansDetail>
     {
+        Task<int> CountProcurementPlanDetailsInYearAsync(int year);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IProcurementPlanRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IProcurementPlanRepository.cs
@@ -5,5 +5,6 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
 {
     public interface IProcurementPlanRepository : IGenericRepository<ProcurementPlan>
     {
+        Task<int> CountProcurementPlansInYearAsync(int year);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ProcurementPlanDetailsRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ProcurementPlanDetailsRepository.cs
@@ -11,5 +11,11 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
     {
         public ProcurementPlanDetailsRepository(DakLakCoffee_SCMContext context) => _context = context;
 
+        public async Task<int> CountProcurementPlanDetailsInYearAsync(int year)
+        {
+            return await _context.ProcurementPlansDetails
+                .CountAsync(p => p.Plan.StartDate.HasValue && p.Plan.StartDate.Value.Year == year);
+        }
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ProcurementPlanRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ProcurementPlanRepository.cs
@@ -9,11 +9,10 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
     public class ProcurementPlanRepository : GenericRepository<ProcurementPlan>, IProcurementPlanRepository
     {
         public ProcurementPlanRepository(DakLakCoffee_SCMContext context) => _context = context;
-        public async Task<ProcurementPlan> CreateProcurementPlanAsync(ProcurementPlan procurementPlan)
+        public async Task<int> CountProcurementPlansInYearAsync(int year)
         {
-            _context.ProcurementPlans.Add(procurementPlan);
-            await _context.SaveChangesAsync();
-            return procurementPlan;
+            return await _context.ProcurementPlans
+                .CountAsync(p => p.StartDate.HasValue && p.StartDate.Value.Year == year);
         }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Generators/IProcurementPlanCodeGenerator.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Generators/IProcurementPlanCodeGenerator.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Services.Generators
+{
+    public interface IProcurementPlanCodeGenerator
+    {
+        Task<string> GenerateProcurementPlanCodeAsync();
+        Task<string> GenerateProcurementPlanDetailsCodeAsync();
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Generators/ProcurementPlanCodeGenerator.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Generators/ProcurementPlanCodeGenerator.cs
@@ -1,0 +1,28 @@
+﻿using DakLakCoffeeSupplyChain.Repositories.UnitOfWork;
+
+namespace DakLakCoffeeSupplyChain.Services.Generators
+{
+    public class ProcurementPlanCodeGenerator (IUnitOfWork unitOfWork) : IProcurementPlanCodeGenerator
+    {
+        private readonly IUnitOfWork _unitOfWork = unitOfWork;
+        public async Task<string> GenerateProcurementPlanCodeAsync()
+        {
+            var currentYear = DateTime.UtcNow.Year;
+
+            // Đếm số procurement plan tạo trong năm
+            var count = await _unitOfWork.ProcurementPlanRepository.CountProcurementPlansInYearAsync(currentYear);
+
+            return $"PLAN-{currentYear}-{(count + 1):D4}";
+        }
+
+        public async Task<string> GenerateProcurementPlanDetailsCodeAsync()
+        {
+            var currentYear = DateTime.UtcNow.Year;
+
+            // Đếm số procurement plan detail tạo trong năm
+            var count = await _unitOfWork.ProcurementPlanDetailsRepository.CountProcurementPlanDetailsInYearAsync(currentYear);
+
+            return $"PLD-{currentYear}-{(count + 1):D4}";
+        }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcurementPlanService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcurementPlanService.cs
@@ -1,4 +1,5 @@
-﻿using DakLakCoffeeSupplyChain.Services.Base;
+﻿using DakLakCoffeeSupplyChain.Common.DTOs.ProcurementPlanDTOs;
+using DakLakCoffeeSupplyChain.Services.Base;
 
 namespace DakLakCoffeeSupplyChain.Services.IServices
 {
@@ -9,5 +10,6 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> GetById(Guid planId);
         Task<IServiceResult> GetByIdExceptDisablePlanDetails(Guid planId);
         Task<IServiceResult> SoftDeleteById(Guid planId);
+        Task<IServiceResult> Create(ProcurementPlanCreateDto procurementPlanDto);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/ProcurementPlanMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/ProcurementPlanMapper.cs
@@ -54,6 +54,7 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 Title = entity.Title ?? string.Empty,
                 Description = entity.Description ?? string.Empty,
                 TotalQuantity = entity.TotalQuantity,
+                CreatedById = entity.CreatedBy,
                 CreatedBy = entity.CreatedByNavigation == null ? null : new BusinessManagerSummaryDto
                 {
                     ManagerId = entity.CreatedByNavigation.ManagerId,
@@ -87,7 +88,6 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                         TypicalRegion = p.CoffeeType.TypicalRegion,
                         SpecialtyLevel = p.CoffeeType.SpecialtyLevel
                     },
-                    //CropType = p.CropType, //Có khả năng field này bị thừa
                     TargetQuantity = p.TargetQuantity,
                     TargetRegion = p.TargetRegion,
                     MinimumRegistrationQuantity = p.MinimumRegistrationQuantity,
@@ -107,18 +107,35 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
             };
         }
 
-        // Mapper ProcurementPlanViewAllDto
-        public static ProcurementPlan MapToProcurementPlanCreateDto(this ProcurementPlanCreateDto dto, Guid BusinessManager)
+        // Mapper ProcurementPlanCreateDto
+        public static ProcurementPlan MapToProcurementPlanCreateDto(this ProcurementPlanCreateDto dto, string planCode, string planDetailCode)
         {
             return new ProcurementPlan
             {
-                PlanId = Guid.NewGuid(), // Assuming PlanID is generated here
+                PlanId = Guid.NewGuid(),
+                PlanCode = planCode,
                 Title = dto.Title,
                 Description = dto.Description,
+                TotalQuantity = 0, // Cái này chưa có default 0 trong db
                 StartDate = dto.StartDate,
                 EndDate = dto.EndDate,
-                CreatedBy = BusinessManager,
+                CreatedBy = dto.CreatedById,
                 Status = dto.Status.ToString(),
+                ProcurementPlansDetails = [.. dto.ProcurementPlansDetails
+                .Select(detail => new ProcurementPlansDetail
+                {
+                    PlanDetailsId = Guid.NewGuid(),
+                    PlanDetailCode = planDetailCode,
+                    CoffeeTypeId = detail.CoffeeType,
+                    CropType = "Arabica", //Set mặc định cho CropType, trường này sẽ được loại bỏ trong tương lai
+                    TargetQuantity = detail.TargetQuantity,
+                    TargetRegion = detail.TargetRegion,
+                    MinimumRegistrationQuantity = detail.MinimumRegistrationQuantity,
+                    MinPriceRange = detail.MinPriceRange,
+                    MaxPriceRange = detail.MaxPriceRange,
+                    Note = detail.Note,
+                    Status = detail.Status.ToString()
+                })]
             };
         }
     }


### PR DESCRIPTION
### 🚀 Feature: Create Procurement Plan API

This pull request introduces the API for creating procurement plans in the system.

#### ✅ Implemented

- Endpoint: `POST /api/procurement-plans`
- Request validation and schema definition
- Database interaction for persisting procurement plans
- Basic error handling and response formatting

#### 📌 Highlights

- Supports creation of a new procurement plan with relevant metadata (e.g., title, expected quantity, time frame, related business unit).
- Ensures data integrity via schema-level constraints and validations.
- Designed with extensibility in mind for future enhancements (e.g., approval workflow, supplier linkage).

#### 🧪 Test Coverage

- Unit tests for service layer logic
- Integration tests for API behavior with edge case handling

---

Let me know if this needs to be extended to support bulk creation or linked commitment data in the next iteration.
