### PR TITLE
feat(business-buyer): implement update API with validation, duplicate TaxId check, and DTO mapping

### DIFF
--- a/Database/DakLakCoffee_SCM.sql
+++ b/Database/DakLakCoffee_SCM.sql
@@ -216,7 +216,7 @@ GO
 -- Table BusinessBuyers
 CREATE TABLE BusinessBuyers (
   BuyerID UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),    
-  BuyerCode VARCHAR(50) UNIQUE,                                    -- BUY-2024-025
+  BuyerCode VARCHAR(50) UNIQUE,                                    -- BM-2025-0001-BUY-2025-001
   CreatedBy UNIQUEIDENTIFIER NOT NULL,                             -- Người tạo buyer (BusinessManager)
   CompanyName NVARCHAR(100) NOT NULL,                              -- Tên doanh nghiệp mua hàng
   ContactPerson NVARCHAR(100),                                     -- Người đại diện ký hợp đồng
@@ -1493,7 +1493,7 @@ INSERT INTO BusinessBuyers (
     CompanyAddress, TaxID, Email, Phone, CreatedAt, UpdatedAt
 )
 VALUES (
-    'ED49B648-F170-48AC-8535-823C80381179', 'BUY-2025-0001', @BMID, N'CTCP Thương Mại Xuất Khẩu VinCafé',
+    'ED49B648-F170-48AC-8535-823C80381179', 'BM-2025-0001-BUY-2025-001', @BMID, N'CTCP Thương Mại Xuất Khẩu VinCafé',
     N'Nguyễn Văn Hậu', N'Tổng Giám Đốc', N'123 Đường Cà Phê, P. Tân Lợi, TP. Buôn Ma Thuột, Đắk Lắk',
     '6001234567', 'vincafe@coffee.com.vn', '02623779999',
     '2025-06-15 11:37:11', '2025-06-15 11:37:11'

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessBuyersController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessBuyersController.cs
@@ -97,6 +97,31 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             return StatusCode(500, result.Message);
         }
 
+        // PUT api/<BusinessBuyersController>/{buyerId}
+        [HttpPut("{buyerId}")]
+        public async Task<IActionResult> UpdateRoleAsync(Guid buyerId, [FromBody] BusinessBuyerUpdateDto businessBuyerDto)
+        {
+            // So sánh route id với dto id để đảm bảo tính nhất quán
+            if (buyerId != businessBuyerDto.BuyerId)
+                return BadRequest("ID trong route không khớp với ID trong nội dung.");
+
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var result = await _businessBuyerService.Update(businessBuyerDto);
+
+            if (result.Status == Const.SUCCESS_UPDATE_CODE)
+                return Ok(result.Data);
+
+            if (result.Status == Const.FAIL_UPDATE_CODE)
+                return Conflict(result.Message);
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy khách hàng để cập nhật.");
+
+            return StatusCode(500, result.Message);
+        }
+
         // PATCH: api/<BusinessBuyersController>/soft-delete/{buyerId}
         [HttpPatch("soft-delete/{buyerId}")]
         public async Task<IActionResult> SoftDeleteBusinessBuyerByIdAsync(Guid buyerId)

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/BusinessBuyerDTOs/BusinessBuyerUpdateDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/BusinessBuyerDTOs/BusinessBuyerUpdateDto.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.BusinessBuyerDTOs
+{
+    public class BusinessBuyerUpdateDto
+    {
+        [Required(ErrorMessage = "Mã khách hàng không được để trống.")]
+        public Guid BuyerId { get; set; }
+
+        [Required(ErrorMessage = "Tên công ty không được để trống.")]
+        [StringLength(100, MinimumLength = 2, ErrorMessage = "Tên công ty phải từ 2 đến 100 ký tự.")]
+        public string CompanyName { get; set; } = string.Empty;
+
+        [StringLength(100, ErrorMessage = "Tên người đại diện không được vượt quá 100 ký tự.")]
+        [RegularExpression(@"^[\p{L}\s'.-]+$", ErrorMessage = "Tên người đại diện không hợp lệ.")]
+        public string ContactPerson { get; set; } = string.Empty;
+
+        [StringLength(50, ErrorMessage = "Chức vụ không được vượt quá 50 ký tự.")]
+        public string Position { get; set; } = string.Empty;
+
+        [StringLength(255, ErrorMessage = "Địa chỉ công ty không được vượt quá 255 ký tự.")]
+        public string CompanyAddress { get; set; } = string.Empty;
+
+        [RegularExpression(@"^\d{10,14}$", ErrorMessage = "Mã số thuế phải từ 10 đến 14 chữ số.")]
+        public string TaxId { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Email không được để trống.")]
+        [EmailAddress(ErrorMessage = "Địa chỉ email không hợp lệ.")]
+        [MaxLength(255, ErrorMessage = "Email không được vượt quá 255 ký tự.")]
+        public string Email { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Số điện thoại không được để trống.")]
+        [RegularExpression(@"^\+?[0-9]{10,15}$", ErrorMessage = "Số điện thoại phải từ 10 đến 15 chữ số.")]
+        public string PhoneNumber { get; set; } = string.Empty;
+
+        [StringLength(255, ErrorMessage = "Website không được vượt quá 255 ký tự.")]
+        [Url(ErrorMessage = "Website không hợp lệ.")]
+        public string? Website { get; set; }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessBuyerService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessBuyerService.cs
@@ -16,6 +16,8 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Create(BusinessBuyerCreateDto businessBuyerDto, Guid userId);
 
+        Task<IServiceResult> Update(BusinessBuyerUpdateDto businessBuyerDto);
+
         Task<IServiceResult> SoftDeleteById(Guid buyerId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/BusinessBuyerMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/BusinessBuyerMapper.cs
@@ -68,5 +68,19 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 CreatedBy = managerId
             };
         }
+
+        // Mapper BusinessBuyerUpdateDto
+        public static void MapToUpdateBusinessBuyer(this BusinessBuyerUpdateDto dto, BusinessBuyer businessBuyer)
+        {
+            businessBuyer.CompanyName = dto.CompanyName;
+            businessBuyer.ContactPerson = dto.ContactPerson;
+            businessBuyer.Position = dto.Position;
+            businessBuyer.CompanyAddress = dto.CompanyAddress;
+            businessBuyer.TaxId = dto.TaxId;
+            businessBuyer.Email = dto.Email;
+            businessBuyer.Phone = dto.PhoneNumber;
+            businessBuyer.Website = dto.Website;
+            businessBuyer.UpdatedAt = DateHelper.NowVietnamTime(); // Cập nhật thời gian chỉnh sửa
+        }
     }
 }


### PR DESCRIPTION
### ✅ Summary

This PR introduces the full implementation of the **Update API for BusinessBuyer**, including validation, duplication checks, DTO mapping, and service/controller integration.

---

### ✨ Changes

- Added `BusinessBuyerUpdateDto` with full annotation-based validation
- Implemented `Update` method in `BusinessBuyerService` with:
  - Business rule to ensure `TaxId` uniqueness per creator (`CreatedBy`)
  - Mapping logic from `UpdateDto` to existing entity
  - Vietnam time update on `UpdatedAt`
- Updated `BusinessBuyerMapper` to support `.MapToExistingBusinessBuyer(...)`
- Updated controller endpoint to support `PUT` with `BuyerId` from DTO
- Synced database model if needed (`.sql` file)

---

### 📁 Files Changed

- `BusinessBuyerUpdateDto.cs`
- `BusinessBuyerService.cs`
- `BusinessBuyerMapper.cs`
- `BusinessBuyersController.cs`
- `IBusinessBuyerService.cs`
- `DakLakCoffee_SCM.sql` (minor update if applicable)

---

### 🧪 Testing

- ✅ Successfully tested update with valid data
- ✅ Prevented duplicate `TaxId` under same BusinessManager
- ✅ Handled case of updating non-existent or deleted buyer

---

