### PR TITLE
feat(contract): implement GetById API with full detail view including contract items and coffee type

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractsController.cs
@@ -34,5 +34,20 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             return StatusCode(500, result.Message);
         }
+
+        // GET api/<ContractsController>/{contractId}
+        [HttpGet("{contractId}")]
+        public async Task<IActionResult> GetById(Guid contractId)
+        {
+            var result = await _contractService.GetById(contractId);
+
+            if (result.Status == Const.SUCCESS_READ_CODE)
+                return Ok(result.Data);              // Trả object chi tiết
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound(result.Message);     // Trả 404 nếu không tìm thấy
+
+            return StatusCode(500, result.Message);  // Lỗi hệ thống
+        }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ContractDTOs/ContractItemDTOs/ContractItemViewDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ContractDTOs/ContractItemDTOs/ContractItemViewDto.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.ContractDTOs.ContractItemDTOs
+{
+    public class ContractItemViewDto
+    {
+        public Guid ContractItemId { get; set; }
+
+        public string ContractItemCode { get; set; } = string.Empty;
+
+        public Guid CoffeeTypeId { get; set; }
+
+        public string CoffeeTypeName { get; set; } = string.Empty;
+
+        public double? Quantity { get; set; }
+
+        public double? UnitPrice { get; set; }
+
+        public double? DiscountAmount { get; set; }
+
+        public string Note { get; set; } = string.Empty;
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ContractDTOs/ContractViewDetailDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ContractDTOs/ContractViewDetailDto.cs
@@ -1,0 +1,51 @@
+﻿using DakLakCoffeeSupplyChain.Common.DTOs.ContractDTOs.ContractItemDTOs;
+using DakLakCoffeeSupplyChain.Common.Enum.ContractEnums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.ContractDTOs
+{
+    public class ContractViewDetailDto
+    {
+        public Guid ContractId { get; set; }
+
+        public string ContractCode { get; set; } = string.Empty;
+
+        public string ContractNumber { get; set; } = string.Empty;
+
+        public string ContractTitle { get; set; } = string.Empty;
+
+        public string ContractFileUrl { get; set; } = string.Empty;
+
+        public string SellerName { get; set; } = string.Empty;
+
+        public string BuyerName { get; set; } = string.Empty;
+
+        public int? DeliveryRounds { get; set; }
+
+        public double? TotalQuantity { get; set; }
+
+        public double? TotalValue { get; set; }
+
+        public DateOnly? StartDate { get; set; }
+
+        public DateOnly? EndDate { get; set; }
+
+        public DateTime? SignedAt { get; set; }
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public ContractStatus Status { get; set; } = ContractStatus.NotStarted;
+
+        public string CancelReason { get; set; } = string.Empty;
+
+        public DateTime CreatedAt { get; set; }
+
+        public DateTime UpdatedAt { get; set; }
+
+        public List<ContractItemViewDto> Items { get; set; } = new();
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractService.cs
@@ -10,5 +10,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
     public interface IContractService
     {
         Task<IServiceResult> GetAll();
+
+        Task<IServiceResult> GetById(Guid contractId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/ContractMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/ContractMapper.cs
@@ -1,4 +1,5 @@
 ﻿using DakLakCoffeeSupplyChain.Common.DTOs.ContractDTOs;
+using DakLakCoffeeSupplyChain.Common.DTOs.ContractDTOs.ContractItemDTOs;
 using DakLakCoffeeSupplyChain.Common.Enum.ContractEnums;
 using DakLakCoffeeSupplyChain.Common.Enum.UserAccountEnums;
 using DakLakCoffeeSupplyChain.Repositories.Models;
@@ -33,6 +34,50 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 StartDate = contract.StartDate,
                 EndDate = contract.EndDate,
                 Status = status
+            };
+        }
+
+        // Mapper ContractViewDetailDto
+        public static ContractViewDetailDto MapToContractViewDetailDto(this Contract contract)
+        {
+            // Parse Status string to enum
+            ContractStatus status = Enum.TryParse<ContractStatus>(contract.Status, ignoreCase: true, out var parsedStatus)
+                ? parsedStatus
+                : ContractStatus.NotStarted;
+
+            return new ContractViewDetailDto
+            {
+                ContractId = contract.ContractId,
+                ContractCode = contract.ContractCode ?? string.Empty,
+                ContractNumber = contract.ContractNumber ?? string.Empty,
+                ContractTitle = contract.ContractTitle ?? string.Empty,
+                ContractFileUrl = contract.ContractFileUrl ?? string.Empty,
+                SellerName = contract.Seller?.User?.Name ?? "N/A",
+                BuyerName = contract.Buyer?.CompanyName ?? "N/A",
+                DeliveryRounds = contract.DeliveryRounds,
+                TotalQuantity = contract.TotalQuantity,
+                TotalValue = contract.TotalValue,
+                StartDate = contract.StartDate,
+                EndDate = contract.EndDate,
+                SignedAt = contract.SignedAt,
+                Status = status,
+                CancelReason = contract.CancelReason ?? string.Empty,
+                CreatedAt = contract.CreatedAt,
+                UpdatedAt = contract.UpdatedAt,
+                Items = contract.ContractItems
+                    .Where(item => !item.IsDeleted)
+                    .Select(item => new ContractItemViewDto
+                    {
+                        ContractItemId = item.ContractItemId,
+                        ContractItemCode = item.ContractItemCode ?? string.Empty,
+                        CoffeeTypeId = item.CoffeeTypeId,
+                        CoffeeTypeName = item.CoffeeType?.TypeName ?? "Unknown",
+                        Quantity = item.Quantity,
+                        UnitPrice = item.UnitPrice,
+                        DiscountAmount = item.DiscountAmount,
+                        Note = item.Note ?? string.Empty
+                    })
+                    .ToList()
             };
         }
     }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ContractService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ContractService.cs
@@ -58,5 +58,41 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 );
             }
         }
+
+        public async Task<IServiceResult> GetById(Guid contractId)
+        {
+            // Tìm contract theo ID
+            var contract = await _unitOfWork.ContractRepository.GetByIdAsync(
+                predicate: c => c.ContractId == contractId,
+                include: query => query
+                   .Include(c => c.Buyer)
+                   .Include(c => c.Seller)
+                      .ThenInclude(s => s.User)
+                   .Include(c => c.ContractItems)
+                      .ThenInclude(ci => ci.CoffeeType),
+                asNoTracking: true
+            );
+
+            // Kiểm tra nếu không tìm thấy contract
+            if (contract == null)
+            {
+                return new ServiceResult(
+                    Const.WARNING_NO_DATA_CODE,
+                    Const.WARNING_NO_DATA_MSG,
+                    new ContractViewDetailDto()  // Trả về DTO rỗng
+                );
+            }
+            else
+            {
+                // Map sang DTO chi tiết để trả về
+                var contractDto = contract.MapToContractViewDetailDto();
+
+                return new ServiceResult(
+                    Const.SUCCESS_READ_CODE,
+                    Const.SUCCESS_READ_MSG,
+                    contractDto
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
### ✅ Summary

This PR adds the **GetById API** for `Contract`, which returns a detailed view including:
- Contract metadata (code, title, parties, dates, value, status)
- List of `ContractItems`
- Name of each `CoffeeType` associated with items

---

### ✨ Changes

- Added new DTO: `ContractViewDetailDto`
- Added nested DTO: `ContractItemViewDto` under `ContractItemDTOs`
- Implemented `MapToContractViewDetailDto()` in `ContractMapper`
- Extended service: `ContractService.GetById(...)`
- Updated controller: `ContractsController`
- Adjusted EF query to include `ContractItems` and their related `CoffeeType`

---

### 📁 Affected Files

- `ContractService.cs`
- `ContractMapper.cs`
- `IContractService.cs`
- `ContractsController.cs`
- `ContractViewDetailDto.cs`
- `ContractItemViewDto.cs`

---

### 🧪 Testing

- ✅ Verified API returns expected structure and data
- ✅ Confirmed coffee type names are loaded properly
- ✅ Handled case when `ContractId` does not exist (returns empty DTO with warning)

---

### 📌 Notes

- This completes the `GetById` logic for contract detail view
- Future improvement: include delivery batches if needed
