### PR TITLE
feat(processing-stage): implement create stage with detail response

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingStageController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingStageController.cs
@@ -49,6 +49,21 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             return StatusCode(500, result.Message); 
         }
+
+        [HttpPost]
+        //[Authorize(Roles = "Admin,BusinessManager,BusinessStaff")]
+        public async Task<IActionResult> Create([FromBody] CreateProcessingStageDto dto)
+        {
+            var result = await _processingStageService.CreateAsync(dto);
+
+            if (result.Status == Const.SUCCESS_CREATE_CODE)
+                return Ok(result.Data); // hoặc return Created(...) nếu cần RESTful hơn
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE || result.Status == Const.WARNING_NO_DATA_CODE)
+                return BadRequest(result);
+
+            return StatusCode(500, result.Message); // lỗi không mong muốn
+        }
     }
 
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcessingMethodStageDTOs/CreateProcessingStageDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcessingMethodStageDTOs/CreateProcessingStageDto.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.ProcessingMethodStageDTOs
+{
+    public class CreateProcessingStageDto
+    {
+        public string StageCode { get; set; } = string.Empty;
+        public string StageName { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public int OrderIndex { get; set; }
+        public bool IsRequired { get; set; }
+        public int MethodId { get; set; }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IProcessingStageRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IProcessingStageRepository.cs
@@ -12,5 +12,6 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
     {
         Task<List<ProcessingStage>> GetAllStagesAsync();
      
+        Task CreateAsync(ProcessingStage entity);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ProcessingStageRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ProcessingStageRepository.cs
@@ -30,5 +30,9 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
                 .AsNoTracking()
                 .ToListAsync();
         }
+        public async Task CreateAsync(ProcessingStage entity)
+        {
+            await _context.AddAsync(entity);
+        }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingStageService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingStageService.cs
@@ -13,5 +13,6 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
     {
         Task<IServiceResult> GetAll();
         Task<IServiceResult> GetDetailByIdAsync(int stageId);
+        Task<IServiceResult> CreateAsync(CreateProcessingStageDto dto);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/ProcessingStageMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/ProcessingStageMapper.cs
@@ -26,7 +26,7 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 MethodName = stage.Method?.Name ?? string.Empty
             };
         }
-        public static ProcessingStageViewDetailDto ToDetailDto(this ProcessingStage entity)
+        public static ProcessingStageViewDetailDto MapToProcessingStageViewDetailDto(this ProcessingStage entity)
         {
             return new ProcessingStageViewDetailDto
             {
@@ -42,6 +42,21 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 CreatedAt = entity.CreatedAt,
                 UpdatedAt = entity.UpdatedAt,
                 IsDeleted = entity.IsDeleted
+            };
+        }
+        public static ProcessingStage MapToProcessingStageCreateEntity(this CreateProcessingStageDto dto)
+        {
+            return new ProcessingStage
+            {
+                StageCode = dto.StageCode,
+                StageName = dto.StageName,
+                Description = dto.Description,
+                OrderIndex = dto.OrderIndex,
+                IsRequired = dto.IsRequired,
+                MethodId = dto.MethodId,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                IsDeleted = false
             };
         }
     }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProcessingStageService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProcessingStageService.cs
@@ -61,7 +61,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 );
             }
 
-            var dto = stage.ToDetailDto();
+            var dto = stage.MapToProcessingStageViewDetailDto();
 
             return new ServiceResult(
                 Const.SUCCESS_READ_CODE,
@@ -69,5 +69,34 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 dto
             );
         }
+        public async Task<IServiceResult> CreateAsync(CreateProcessingStageDto dto)
+        {
+            try
+            {
+                var entity = dto.MapToProcessingStageCreateEntity(); // map DTO -> Entity
+                await _unitOfWork.ProcessingStageRepository.CreateAsync(entity);
+                var result = await _unitOfWork.SaveChangesAsync();
+
+                if (result > 0)
+                {
+                    
+                    var created = await _unitOfWork.ProcessingStageRepository.GetByIdAsync (entity.StageId);
+
+                    if (created == null)
+                        return new ServiceResult(Const.SUCCESS_CREATE_CODE, Const.SUCCESS_CREATE_MSG, null);
+
+                    var viewDto = created.MapToProcessingStageViewDetailDto();
+                    return new ServiceResult(Const.SUCCESS_CREATE_CODE, Const.SUCCESS_CREATE_MSG, viewDto);
+                }
+
+                return new ServiceResult(Const.FAIL_CREATE_CODE, Const.FAIL_CREATE_MSG);
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult(Const.ERROR_EXCEPTION, ex.Message);
+            }
+        }
+
+
     }
 }


### PR DESCRIPTION
### ✅ Features
- Implemented `CreateAsync()` for `ProcessingStage`
- Returned full `ProcessingStageViewDetailDto` after creation
- Included `MethodName`, `MethodCode`, and audit fields in the response

### 🔧 Updates
- Added `CreateAsync` method in `ProcessingStageService`
- Updated `IProcessingStageRepository` and `ProcessingStageRepository` to support creation
- Fixed missing `GetStageByIdAsync` or used `GetByIdAsync` with custom query including navigation

### 📌 Result Example
```json

  {
    "stageId": 26,
    "stageCode": "drying",
    "stageName": "Phơi nắng",
    "methodId": 1,
    "methodName": "Sơ chế khô (Natural)",
    "createdAt": "2025-06-22T13:00:00Z",
    ...
  }

