### PR TITLE
feat(contract): implement soft delete with cascade on related contract items

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractsController.cs
@@ -49,5 +49,30 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             return StatusCode(500, result.Message);  // Lỗi hệ thống
         }
+
+        // PATCH: api/<ContractsController>/soft-delete/{contractId}
+        [HttpPatch("soft-delete/{contractId}")]
+        public async Task<IActionResult> SoftDeleteContractByIdAsync(Guid contractId)
+        {
+            var result = await _contractService.SoftDeleteContractById(contractId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok("Xóa mềm thành công.");
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy hợp đồng.");
+
+            if (result.Status == Const.FAIL_DELETE_CODE)
+                return Conflict("Xóa mềm thất bại.");
+
+            return StatusCode(500, result.Message);
+        }
+
+        private async Task<bool> ContractExistsAsync(Guid contractId)
+        {
+            var result = await _contractService.GetById(contractId);
+
+            return result.Status == Const.SUCCESS_READ_CODE;
+        }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ContractDTOs/ContractDeleteDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ContractDTOs/ContractDeleteDto.cs
@@ -5,11 +5,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace DakLakCoffeeSupplyChain.Common.DTOs.BusinessBuyerDTOs
+namespace DakLakCoffeeSupplyChain.Common.DTOs.ContractDTOs
 {
-    public class BusinessBuyerDeleteDto
+    public class ContractDeleteDto
     {
         [Required]
-        public Guid BuyerId { get; set; }
+        public Guid ContractId { get; set; }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IContractItemRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IContractItemRepository.cs
@@ -1,0 +1,14 @@
+﻿using DakLakCoffeeSupplyChain.Repositories.Base;
+using DakLakCoffeeSupplyChain.Repositories.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
+{
+    public interface IContractItemRepository : IGenericRepository<ContractItem>
+    {
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ContractItemRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ContractItemRepository.cs
@@ -1,0 +1,20 @@
+﻿using DakLakCoffeeSupplyChain.Repositories.Base;
+using DakLakCoffeeSupplyChain.Repositories.DBContext;
+using DakLakCoffeeSupplyChain.Repositories.IRepositories;
+using DakLakCoffeeSupplyChain.Repositories.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Repositories.Repositories
+{
+    public class ContractItemRepository : GenericRepository<ContractItem>, IContractItemRepository
+    {
+        public ContractItemRepository() { }
+
+        public ContractItemRepository(DakLakCoffee_SCMContext context)
+            => _context = context;
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/IUnitOfWork.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/IUnitOfWork.cs
@@ -23,6 +23,8 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
 
         IContractRepository ContractRepository { get; }
 
+        IContractItemRepository ContractItemRepository { get; }
+
         IProcurementPlanRepository ProcurementPlanRepository { get; }
 
         IProcurementPlanDetailsRepository ProcurementPlanDetailsRepository { get; }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/UnitOfWork.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/UnitOfWork.cs
@@ -16,6 +16,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
         private IBusinessManagerRepository? businessManagerRepository;
         private IBusinessBuyerRepository? businessBuyerRepository;
         private IContractRepository? contractRepository;
+        private IContractItemRepository? contractItemRepository;
         private IProductRepository? productRepository;
         private ISystemConfigurationRepository? systemConfigurationRepository;
         private IFarmerRepository? farmerRepository;
@@ -83,6 +84,14 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
             get
             {
                 return contractRepository ??= new ContractRepository(context);
+            }
+        }
+
+        public IContractItemRepository ContractItemRepository
+        {
+            get
+            {
+                return contractItemRepository ??= new ContractItemRepository(context);
             }
         }
 

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractService.cs
@@ -12,5 +12,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> GetAll();
 
         Task<IServiceResult> GetById(Guid contractId);
+
+        Task<IServiceResult> SoftDeleteContractById(Guid contractId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ContractService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ContractService.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 using DakLakCoffeeSupplyChain.Common.DTOs.ContractDTOs;
 using DakLakCoffeeSupplyChain.Services.Mappers;
+using DakLakCoffeeSupplyChain.Common.Helpers;
 
 namespace DakLakCoffeeSupplyChain.Services.Services
 {
@@ -27,6 +28,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
         {
             // Truy vấn tất cả hợp đồng từ repository
             var contracts = await _unitOfWork.ContractRepository.GetAllAsync(
+                predicate: c => !c.IsDeleted,
                 include: query => query
                    .Include(c => c.Buyer)
                    .Include(c => c.Seller)
@@ -63,12 +65,12 @@ namespace DakLakCoffeeSupplyChain.Services.Services
         {
             // Tìm contract theo ID
             var contract = await _unitOfWork.ContractRepository.GetByIdAsync(
-                predicate: c => c.ContractId == contractId,
+                predicate: c => c.ContractId == contractId && !c.IsDeleted,
                 include: query => query
                    .Include(c => c.Buyer)
                    .Include(c => c.Seller)
                       .ThenInclude(s => s.User)
-                   .Include(c => c.ContractItems)
+                   .Include(c => c.ContractItems.Where(ci => !ci.IsDeleted))
                       .ThenInclude(ci => ci.CoffeeType),
                 asNoTracking: true
             );
@@ -91,6 +93,79 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                     Const.SUCCESS_READ_CODE,
                     Const.SUCCESS_READ_MSG,
                     contractDto
+                );
+            }
+        }
+
+        public async Task<IServiceResult> SoftDeleteContractById(Guid contractId)
+        {
+            try
+            {
+                // Tìm contract theo ID
+                var contract = await _unitOfWork.ContractRepository.GetByIdAsync(
+                    predicate: c => c.ContractId == contractId,
+                    include: query => query
+                       .Include(c => c.Buyer)
+                       .Include(c => c.Seller)
+                          .ThenInclude(s => s.User)
+                       .Include(c => c.ContractItems)
+                          .ThenInclude(ci => ci.CoffeeType),
+                    asNoTracking: false
+                );
+
+                // Kiểm tra nếu không tồn tại
+                if (contract == null)
+                {
+                    return new ServiceResult(
+                        Const.WARNING_NO_DATA_CODE,
+                        Const.WARNING_NO_DATA_MSG
+                    );
+                }
+                else
+                {
+                    // Đánh dấu contract là đã xóa
+                    contract.IsDeleted = true;
+                    contract.UpdatedAt = DateHelper.NowVietnamTime();
+
+                    // Đánh dấu tất cả ContractItems là đã xóa
+                    foreach (var item in contract.ContractItems)
+                    {
+                        item.IsDeleted = true;
+                        item.UpdatedAt = DateHelper.NowVietnamTime();
+
+                        // Đảm bảo EF theo dõi thay đổi của item
+                        await _unitOfWork.ContractItemRepository.UpdateAsync(item);
+                    }
+
+                    // Cập nhật xoá mềm contract ở repository
+                    await _unitOfWork.ContractRepository.UpdateAsync(contract);
+
+                    // Lưu thay đổi
+                    var result = await _unitOfWork.SaveChangesAsync();
+
+                    // Kiểm tra kết quả
+                    if (result > 0)
+                    {
+                        return new ServiceResult(
+                            Const.SUCCESS_DELETE_CODE,
+                            Const.SUCCESS_DELETE_MSG
+                        );
+                    }
+                    else
+                    {
+                        return new ServiceResult(
+                            Const.FAIL_DELETE_CODE,
+                            Const.FAIL_DELETE_MSG
+                        );
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Trả về lỗi nếu có exception
+                return new ServiceResult(
+                    Const.ERROR_EXCEPTION,
+                    ex.ToString()
                 );
             }
         }


### PR DESCRIPTION
### ✅ Summary

This pull request enhances the `Contract` module by implementing **soft delete with cascading** to related `ContractItems`. It also ensures both `GetAll` and `GetById` APIs return only active (non-deleted) contracts and items.

---

### ✨ What's Updated

- **Soft delete logic**:
  - When a contract is soft-deleted, all its associated `ContractItems` are also marked `IsDeleted = true`.
  - Ensures data consistency and avoids orphaned items in contract detail view.

- **Filtering enhancement**:
  - `GetAll()` now excludes contracts where `IsDeleted = true`.
  - `GetById()` view excludes soft-deleted contracts and does **not** return `ContractItems` marked as deleted.

---

### 🛠 Affected Files

- `ContractService.cs`: 
  - Updated `SoftDeleteContractById()` to cascade delete to items.
  - Applied `IsDeleted` filtering in `GetAll()` and `GetById()`.

- `IContractItemRepository.cs` & `ContractItemRepository.cs`: 
  - **Newly added** to support update operations on `ContractItem`.

- `IUnitOfWork.cs` & `UnitOfWork.cs`: 
  - Registered the `ContractItemRepository`.

- `ContractsController.cs`: 
  - Updated soft delete endpoint to reflect service changes.

---

### 📌 Notes

- All changes follow the soft delete pattern applied in `BusinessBuyer`.
- Contract detail view will no longer show any `ContractItems` marked as deleted.
- This improves data integrity for front-end rendering and admin filtering.
