### PR TITLE
feat(contract): restrict GetAll to only return contracts of current BusinessManager

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractsController.cs
@@ -1,4 +1,5 @@
 ﻿using DakLakCoffeeSupplyChain.Common;
+using DakLakCoffeeSupplyChain.Common.Helpers;
 using DakLakCoffeeSupplyChain.Services.IServices;
 using DakLakCoffeeSupplyChain.Services.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -24,7 +25,19 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [EnableQuery]
         public async Task<IActionResult> GetAllContractsAsync()
         {
-            var result = await _contractService.GetAll();
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
+            var result = await _contractService.GetAll(userId);
 
             if (result.Status == Const.SUCCESS_READ_CODE)
                 return Ok(result.Data);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractService.cs
@@ -9,7 +9,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 {
     public interface IContractService
     {
-        Task<IServiceResult> GetAll();
+        Task<IServiceResult> GetAll(Guid userId);
 
         Task<IServiceResult> GetById(Guid contractId);
 

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ContractService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ContractService.cs
@@ -24,11 +24,25 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 ?? throw new ArgumentNullException(nameof(unitOfWork));
         }
 
-        public async Task<IServiceResult> GetAll()
+        public async Task<IServiceResult> GetAll(Guid userId)
         {
+            var manager = await _unitOfWork.BusinessManagerRepository.GetByIdAsync(
+                predicate: m => m.UserId == userId,
+                asNoTracking: true
+            );
+
+            if (manager == null)
+            {
+                return new ServiceResult(
+                    Const.WARNING_NO_DATA_CODE,
+                    "Không tìm thấy BusinessManager tương ứng với tài khoản."
+                );
+            }
+
             // Truy vấn tất cả hợp đồng từ repository
             var contracts = await _unitOfWork.ContractRepository.GetAllAsync(
-                predicate: c => !c.IsDeleted,
+                predicate: c => !c.IsDeleted &&
+                                c.SellerId == manager.ManagerId,
                 include: query => query
                    .Include(c => c.Buyer)
                    .Include(c => c.Seller)


### PR DESCRIPTION
## ✨ What’s Changed

- Update `ContractService.GetAll(Guid userId)` logic to only return contracts belonging to the currently authenticated `BusinessManager`.
- Extract `userId` from token and map to `BusinessManager.ManagerId`.
- Ensure `SellerId` in contracts matches the current manager before returning data.

---

## 📂 Affected Components

- `ContractsController.cs`
- `IContractService.cs`
- `ContractService.cs`

---

## ✅ Why

Previously, `GetAll()` returned **all contracts**, including those from unrelated businesses. This change ensures data isolation and privacy between BusinessManagers.

---

## 🔒 Scope

- ✅ BusinessManager can only see their own contracts.
- ❌ No changes for Admin/Other roles (if any).
- ✅ Maintains existing DTO & OData compatibility.

---

## 🧪 How to Test

1. Login as a `BusinessManager`.
2. Call `GET /api/contracts`.
3. Ensure only contracts created by the corresponding `BusinessManager` are returned.

