### PR TITLE
feat(contract-item): implement delete API, sort ContractItems by code in GetById, and ensure null-safe response in create

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractItemsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractItemsController.cs
@@ -39,6 +39,24 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             return StatusCode(500, result.Message);
         }
 
+        // DELETE api/<ContractItemsController>/{contractItemId}
+        [HttpDelete("{contractItemId}")]
+        public async Task<IActionResult> DeleteContractItemByIdAsync(Guid contractItemId)
+        {
+            var result = await _contractItemService.DeleteContractItemById(contractItemId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok("Xóa thành công.");
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy sản phẩm hợp đồng.");
+
+            if (result.Status == Const.FAIL_DELETE_CODE)
+                return Conflict("Xóa thất bại.");
+
+            return StatusCode(500, result.Message);
+        }
+
         // PATCH: api/<ContractItemsController>/soft-delete/{contractItemId}
         [HttpPatch("soft-delete/{contractItemId}")]
         public async Task<IActionResult> SoftDeleteContractItemByIdAsync(Guid contractItemId)

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractItemService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractItemService.cs
@@ -12,6 +12,8 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
     {
         Task<IServiceResult> Create(ContractItemCreateDto contractItemDto);
 
+        Task<IServiceResult> DeleteContractItemById(Guid contractItemId);
+
         Task<IServiceResult> SoftDeleteContractItemById(Guid contractItemId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ContractService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ContractService.cs
@@ -47,7 +47,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                    .Include(c => c.Buyer)
                    .Include(c => c.Seller)
                       .ThenInclude(s => s.User),
-                orderBy: u => u.OrderBy(u => u.ContractCode),
+                orderBy: c => c.OrderBy(c => c.ContractCode),
                 asNoTracking: true
             );
 
@@ -79,7 +79,8 @@ namespace DakLakCoffeeSupplyChain.Services.Services
         {
             // Tìm contract theo ID
             var contract = await _unitOfWork.ContractRepository.GetByIdAsync(
-                predicate: c => c.ContractId == contractId && !c.IsDeleted,
+                predicate: c => c.ContractId == contractId && 
+                                !c.IsDeleted,
                 include: query => query
                    .Include(c => c.Buyer)
                    .Include(c => c.Seller)
@@ -100,6 +101,11 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             }
             else
             {
+                // Sắp xếp danh sách ContractItems theo ContractItemCode tăng dần
+                contract.ContractItems = contract.ContractItems
+                    .OrderBy(ci => ci.ContractItemCode)
+                    .ToList();
+
                 // Map sang DTO chi tiết để trả về
                 var contractDto = contract.MapToContractViewDetailDto();
 


### PR DESCRIPTION
☕ Feature: Hard Delete ContractItem API + Fix Create Response + Sort ContractItems in GetById

📌 Objective  
Implement hard delete API for `ContractItem`, fix potential null reference in create response, and sort `ContractItems` by code when viewing contract detail.

---

✅ Key Changes  
This PR includes:

- **DELETE /api/contractitems/{id}**: Implemented hard delete for ContractItem
- **POST /api/contractitems**:
  - Handled potential `null` in `responseDto` to avoid null reference warning
  - Prevent duplicated coffee type in same contract
- **GET /api/contracts/{id}**:
  - Sort `ContractItems` by `ContractItemCode` (ascending) before mapping to DTO

---

✨ Improvements  
- Response from create API is now null-safe
- Contract detail view is easier to read with ordered `ContractItems`

---

📂 Affected Files  
- `ContractItemsController.cs`  
- `ContractItemService.cs`, `IContractItemService.cs`  
- `ContractService.cs`

---

🔍 Notes  
- Sorting is done in-memory after EF retrieval due to EF Core `.Include()` limitations
- BusinessManager role required for all endpoints

---

✅ Test Cases  
- ✅ Successfully delete contract item via DELETE
- ✅ Prevent duplicate create (same coffee type)
- ✅ Return null-safe `ContractItemViewDto` on create
- ✅ Return contract with sorted `ContractItems` by code

---

🔗 Related  
Modules: ContractItem, Contract  
Role: BusinessManager  
