### PR TITLE
[ProcessingParameter] Add Hard Delete API

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingParametersController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingParametersController.cs
@@ -79,7 +79,7 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             return StatusCode(500, result.Message); // 500 Internal Server Error nếu exception
         }
 
-        [HttpDelete("{parameterId}")]
+        [HttpDelete("soft/{parameterId}")]
         // [Authorize(Roles = "BusinessStaff,Farmer")]
         public async Task<IActionResult> SoftDelete(Guid parameterId)
         {
@@ -93,5 +93,20 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             return StatusCode(500, result.Message);
         }
+        [HttpDelete("hard/{parameterId}")]
+        // [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> HardDelete(Guid parameterId)
+        {
+            var result = await _processingParameterService.HardDeleteAsync(parameterId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok(result.Message);
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound(result.Message);
+
+            return StatusCode(500, result.Message);
+        }
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IProcessingParameterRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IProcessingParameterRepository.cs
@@ -13,6 +13,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
         Task<List<ProcessingParameter>> GetAllActiveAsync();
         Task<ProcessingParameter?> GetByIdAsync(Guid parameterId);
         Task<bool> SoftDeleteAsync(Guid parameterId);
+        Task<bool> HardDeleteAsync(Guid parameterId);
 
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ProcessingParameterRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ProcessingParameterRepository.cs
@@ -48,5 +48,17 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
             _context.ProcessingParameters.Update(entity);
             return true;
         }
+        public async Task<bool> HardDeleteAsync(Guid parameterId)
+        {
+            var entity = await _context.ProcessingParameters
+                .FirstOrDefaultAsync(p => p.ParameterId == parameterId);
+
+            if (entity == null)
+                return false;
+
+            _context.ProcessingParameters.Remove(entity);
+            return true;
+        }
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingParameterService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingParameterService.cs
@@ -15,6 +15,6 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> CreateAsync(ProcessingParameterCreateDto dto);
         Task<IServiceResult> UpdateAsync(ProcessingParameterUpdateDto dto);
         Task<IServiceResult> SoftDeleteAsync(Guid parameterId);
-
+        Task<IServiceResult> HardDeleteAsync(Guid parameterId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProcessingParameterService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProcessingParameterService.cs
@@ -186,5 +186,25 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 );
             }
         }
+        public async Task<IServiceResult> HardDeleteAsync(Guid parameterId)
+        {
+            try
+            {
+                var success = await _unitOfWork.ProcessingParameterRepository.HardDeleteAsync(parameterId);
+                if (!success)
+                {
+                    return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Parameter not found");
+                }
+
+                await _unitOfWork.SaveChangesAsync();
+
+                return new ServiceResult(Const.SUCCESS_DELETE_CODE, "Hard delete success");
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult(Const.ERROR_EXCEPTION, ex.Message);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
## 🧨 Feature: Hard Delete ProcessingParameter

### 📌 Objective
Thêm API `DELETE /api/processingparameter/hard/{parameterId}` để **xóa vĩnh viễn thông số** trong quá trình chế biến (ProcessingParameter). Khác với soft delete, bản ghi sẽ bị xóa khỏi cơ sở dữ liệu.

---

### ✅ Key Changes
- Thêm `HardDeleteAsync(Guid)` trong `Repository` & `Service`
- Controller thêm endpoint `DELETE /hard/{id}`
- Không set `IsDeleted` mà xóa trực tiếp khỏi DB
- Trả kết quả thành công hoặc thông báo không tìm thấy

---

### 🧱 Affected Files
- `ProcessingParameterController.cs`
- `ProcessingParameterService.cs`
- `IProcessingParameterService.cs`
- `ProcessingParameterRepository.cs`
- `IProcessingParameterRepository.cs`

---

### 📁 Added
- API: `DELETE /api/processingparameter/hard/{parameterId}`

---

### 🧪 How to Test
1. Gửi request:DELETE /api/processingparameter/hard/{guid-id}
2. Kiểm tra:
   - Trả về 200 nếu xoá thành công
   - Gọi lại `GET` thì bản ghi đã bị mất hoàn toàn
   - Trả về 404 nếu id không tồn tại

---

### 🧪 Test Cases
- [x] ✅ Xóa vĩnh viễn bản ghi thành công
- [x] ❌ Trả lỗi nếu `parameterId` không tồn tại
- [x] ❌ Không bị ảnh hưởng bởi `IsDeleted` (vẫn xóa)

---

### 🔍 Notes
- Chỉ dùng cho Admin hoặc khi thật sự cần xoá cứng
- Ưu tiên dùng SoftDelete cho thao tác người dùng thông thường

---

### 🔗 Related
- Module: `Processing`
- Table: `ProcessingParameter`
- Roles: `Admin` (hoặc các role có quyền xoá vĩnh viễn)

