### PR TITLE
[ProcessingMethod] Add Soft Delete endpoint

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingMethodController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingMethodController.cs
@@ -1,6 +1,7 @@
 ﻿using DakLakCoffeeSupplyChain.Common;
 using DakLakCoffeeSupplyChain.Common.DTOs.ProcessingMethodDTOs;
 using DakLakCoffeeSupplyChain.Services.IServices;
+using DakLakCoffeeSupplyChain.Services.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -76,6 +77,20 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             if (result.Status == Const.FAIL_DELETE_CODE || result.Status == Const.WARNING_NO_DATA_CODE)
                 return BadRequest(result.Message);
+
+            return StatusCode(500, result.Message);
+        }
+        [HttpDelete("soft/{methodId}")]
+         [Authorize(Roles = "Admin,BusinessManager,BusinessStaff")]
+        public async Task<IActionResult> SoftDelete(int methodId)
+        {
+            var result = await _procesingMethodService.SoftDeleteAsync(methodId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok(result.Message);
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound(result.Message);
 
             return StatusCode(500, result.Message);
         }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IProcessingMethodRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IProcessingMethodRepository.cs
@@ -10,5 +10,6 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
 {
     public interface IProcessingMethodRepository : IGenericRepository<ProcessingMethod>
     {
+        Task<bool> SoftDeleteAsync(int methodId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ProcessingMethodRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ProcessingMethodRepository.cs
@@ -2,6 +2,7 @@
 using DakLakCoffeeSupplyChain.Repositories.DBContext;
 using DakLakCoffeeSupplyChain.Repositories.IRepositories;
 using DakLakCoffeeSupplyChain.Repositories.Models;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,5 +19,20 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
         {
             _context = context;
         }
+        public async Task<bool> SoftDeleteAsync(int methodId)
+        {
+            var method = await _context.ProcessingMethods
+                .FirstOrDefaultAsync(m => m.MethodId == methodId && !m.IsDeleted);
+
+            if (method == null)
+                return false;
+
+            method.IsDeleted = true;
+            method.UpdatedAt = DateTime.UtcNow;
+
+            _context.ProcessingMethods.Update(method);
+            return true;
+        }
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingMethodService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingMethodService.cs
@@ -17,6 +17,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> DeleteById(int methodId);
 
         Task<IServiceResult> CreateAsync(ProcessingMethodCreateDto input);
+        Task<IServiceResult> SoftDeleteAsync(int methodId);
 
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProcessingMethodService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProcessingMethodService.cs
@@ -137,6 +137,24 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 return new ServiceResult(Const.ERROR_EXCEPTION, ex.Message);
             }
         }
+        public async Task<IServiceResult> SoftDeleteAsync(int methodId)
+        {
+            try
+            {
+                var success = await _unitOfWork.ProcessingMethodRepository.SoftDeleteAsync(methodId);
+                if (!success)
+                {
+                    return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Method not found");
+                }
+
+                await _unitOfWork.SaveChangesAsync();
+                return new ServiceResult(Const.SUCCESS_DELETE_CODE, Const.SUCCESS_DELETE_MSG);
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult(Const.ERROR_EXCEPTION, ex.Message);
+            }
+        }
 
     }
 }


### PR DESCRIPTION
## 🗑️ Feature: Soft Delete ProcessingMethod

### 📌 Objective
Introduce a new API to perform **soft deletion** of a `ProcessingMethod`. This avoids physical removal from the database and instead sets `IsDeleted = true`.

---

### ✅ Key Changes
- Added `SoftDeleteAsync(int methodId)` in `IProcessingMethodRepository` and its implementation
- Added `SoftDeleteAsync(int methodId)` in `IProcessingMethodService` and service layer
- New controller endpoint: `DELETE /api/processingmethod/{methodId}`
- Ensured the method updates `IsDeleted = true` and `UpdatedAt = DateTime.UtcNow`

---

### 🧱 Affected Files
- `IProcessingMethodRepository.cs`
- `ProcessingMethodRepository.cs`
- `IProcessingMethodService.cs`
- `ProcessingMethodService.cs`
- `ProcessingMethodController.cs`

---

### 📁 Added
- API: `DELETE /api/processingmethod/{methodId}` for soft delete

---

### 🧪 How to Test
1. **Call** the endpoint:DELETE /api/soft/processingmethod/{id}
2. **Check response:**
- Returns 200 OK → if soft deletion was successful
- Returns 404 Not Found → if ID not found or already deleted
3. **Verify**:
- Method does not show up in `GetAll` calls (which only return `IsDeleted = false`)
- DB still retains the record, but marked as deleted

---

### 🧪 Test Cases
- [x] Soft delete a valid method
- [x] Return 404 if method ID does not exist
- [x] Ensure soft-deleted methods are excluded from normal queries

---

### 🔍 Notes
- This is a safer alternative to hard delete for maintaining data history
- Future enhancements may include undo/restore logic

---

### 🔗 Related
- Entity: `ProcessingMethod`
- Roles: `BusinessManager`, `BusinessStaff`
