### PR TITLE
feat(contract): implement hard delete with cascade removal of related contract items

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractsController.cs
@@ -96,6 +96,24 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             return StatusCode(500, result.Message);
         }
 
+        // DELETE api/<ContractsController>/{contractId}
+        [HttpDelete("{contractId}")]
+        public async Task<IActionResult> DeleteContractByIdAsync(Guid contractId)
+        {
+            var result = await _contractService.DeleteContractById(contractId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok("Xóa thành công.");
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy hợp đồng.");
+
+            if (result.Status == Const.FAIL_DELETE_CODE)
+                return Conflict("Xóa thất bại.");
+
+            return StatusCode(500, result.Message);
+        }
+
         // PATCH: api/<ContractsController>/soft-delete/{contractId}
         [HttpPatch("soft-delete/{contractId}")]
         public async Task<IActionResult> SoftDeleteContractByIdAsync(Guid contractId)

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractService.cs
@@ -17,6 +17,8 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Create(ContractCreateDto contractDto, Guid userId);
 
+        Task<IServiceResult> DeleteContractById(Guid contractId);
+
         Task<IServiceResult> SoftDeleteContractById(Guid contractId);
     }
 }


### PR DESCRIPTION
## ☕ Feature: Hard Delete Contract with Cascade ContractItem Removal

### 📌 Objective
Implement a hard delete feature for `Contract`, ensuring all associated `ContractItems` are also removed from the database. This applies to the `BusinessManager` role and impacts the contract deletion flow in the supply chain management system.

---

### ✅ Key Changes
- Implemented `DeleteContractById` in `ContractService` with manual deletion of linked `ContractItems`
- Updated `ContractsController` to expose new DELETE endpoint with proper role authorization
- Ensured `ContractItems` are loaded with the contract entity and removed before deleting the contract itself

---

### 🧱 Affected Files
- `ContractsController.cs`
- `ContractService.cs`
- `IContractService.cs`

---

### 📁 Added
- *(None)* – logic added to existing service and controller files

---

### 🧪 How to Test
1. **Login** as a `BusinessManager` to obtain a valid JWT token  
2. Send DELETE request to the following endpoint:
   - `DELETE /api/contracts/{contractId}`
   - Header: `Authorization: Bearer {token}`  
3. Ensure the target contract exists and contains related contract items

---

### 🧪 Test Cases
- [x] ✅ Delete a contract with related items → contract and items are removed from DB  
- [x] ❌ Delete a non-existent contract → return 404 Not Found  
- [x] ❌ Delete with invalid or missing token → return 401 Unauthorized  

---

### 🔍 Notes
- Manual cascade is used instead of EF Core cascade delete to maintain explicit service-layer control
- `asNoTracking: false` is applied to allow EF Core to track changes and perform deletion
- No DTO or request body needed for delete; only contractId in route

---

### 🔗 Related
- Modules: `Contract`, `ContractItem`
- Roles: `BusinessManager`
