### PR TITLE
feat(crop-progress): add soft and hard delete following service-repo-controller pattern  refactor(crop-progress-repo): add SoftDelete & PrepareRemove methods to repository  style(crop-progress): clean up comments, exception handling, and use consistent ServiceResult

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropProgressesController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropProgressesController.cs
@@ -84,6 +84,27 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             return NotFound(result.Message);
         }
 
+        [HttpPatch("soft-delete/{progressId}")]
+        public async Task<IActionResult> SoftDeleteById(Guid progressId)
+        {
+            var result = await _cropProgressService.SoftDeleteById(progressId);
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok(result.Message);
+
+            return NotFound(result.Message);
+        }
+
+
+        [HttpDelete("hard/{progressId}")]
+        public async Task<IActionResult> HardDelete(Guid progressId)
+        {
+            var result = await _cropProgressService.DeleteById(progressId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok(result.Message);
+
+            return NotFound(result.Message);
+        }
 
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropStagesController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropStagesController.cs
@@ -94,8 +94,7 @@ public class CropStagesController : ControllerBase
     [Authorize(Roles = "Admin")]
     public async Task<IActionResult> DeleteCropStage(int stageId)
     {
-        var result = await _cropStageService.Delete(stageId);
-
+        var result = await _cropStageService.DeleteById(stageId); 
         if (result.Status == Const.SUCCESS_DELETE_CODE)
             return Ok(result.Message);
 
@@ -109,7 +108,7 @@ public class CropStagesController : ControllerBase
     [Authorize(Roles = "Admin,BusinessManager")]
     public async Task<IActionResult> SoftDeleteCropStage(int stageId)
     {
-        var result = await _cropStageService.SoftDelete(stageId);
+        var result = await _cropStageService.SoftDeleteById(stageId); 
 
         if (result.Status == Const.SUCCESS_DELETE_CODE)
             return Ok(result.Message);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropSeasonRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropSeasonRepository.cs
@@ -18,7 +18,6 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
         Task DeleteCropSeasonDetailsBySeasonIdAsync(Guid cropSeasonId);
 
         Task<bool> ExistsAsync(Expression<Func<CropSeason, bool>> predicate);
-        void SoftDelete(CropSeason entity);
 
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropStageRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropStageRepository.cs
@@ -9,8 +9,5 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
         Task<CropStage?> GetByCodeAsync(string code);
         Task<List<CropStage>> GetAllOrderedAsync();
         Task<CropStage?> GetByIdAsync(int stageId);
-
-        Task DeleteCropCropStageByStageIdAsync(int stageId);
-
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Models/CropProgress.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Models/CropProgress.cs
@@ -42,4 +42,5 @@ public partial class CropProgress
     public virtual CropStage Stage { get; set; }
 
     public virtual Farmer UpdatedByNavigation { get; set; }
+
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonRepository.cs
@@ -61,10 +61,5 @@ public class CropSeasonRepository : GenericRepository<CropSeason>, ICropSeasonRe
         return await _context.CropSeasons.AnyAsync(predicate);
     }
 
-    public void SoftDelete(CropSeason entity)
-    {
-        entity.IsDeleted = true;
-        _context.CropSeasons.Update(entity);
-    }
 
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropStageRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropStageRepository.cs
@@ -35,14 +35,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
                 .FirstOrDefaultAsync(cs => cs.StageId == stageId);
         }
 
-        public async Task DeleteCropCropStageByStageIdAsync(int stageId)
-        {
-            var entity = await _context.CropStages.FindAsync(stageId);
-            if (entity != null)
-            {
-                _context.CropStages.Remove(entity);
-            }
-        }
+
 
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropProgressService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropProgressService.cs
@@ -10,6 +10,12 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> GetById(Guid id);
 
         Task<IServiceResult> Create(CropProgressCreateDto dto);
+
         Task<IServiceResult> Update(CropProgressUpdateDto dto);
+
+        Task<IServiceResult> SoftDeleteById(Guid progressId);
+            
+        Task<IServiceResult> DeleteById(Guid progressId);
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropStageService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropStageService.cs
@@ -15,9 +15,9 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Update(CropStageUpdateDto dto);
 
-        Task<IServiceResult> Delete(int stageId);
+        Task<IServiceResult> DeleteById(int stageId);
+        Task<IServiceResult> SoftDeleteById(int stageId);
 
-        Task<IServiceResult> SoftDelete(int stageId);
 
 
     }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropStageService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropStageService.cs
@@ -1,6 +1,7 @@
 ﻿using DakLakCoffeeSupplyChain.Common;
 using DakLakCoffeeSupplyChain.Common.DTOs.CropStageDto;
 using DakLakCoffeeSupplyChain.Common.DTOs.CropStageDTOs;
+using DakLakCoffeeSupplyChain.Common.Helpers;
 using DakLakCoffeeSupplyChain.Repositories.Models;
 using DakLakCoffeeSupplyChain.Repositories.UnitOfWork;
 using DakLakCoffeeSupplyChain.Services.Base;
@@ -165,55 +166,96 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             }
         }
 
-        public async Task<IServiceResult> Delete(int stageId)
+        public async Task<IServiceResult> DeleteById(int stageId)
         {
             try
             {
+                // Tìm giai đoạn theo ID
                 var stage = await _unitOfWork.CropStageRepository.GetByIdAsync(stageId);
 
+                // Không tìm thấy
                 if (stage == null)
-                    return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Giai đoạn không tồn tại hoặc đã bị xóa.");
+                {
+                    return new ServiceResult(
+                        Const.WARNING_NO_DATA_CODE,
+                        Const.WARNING_NO_DATA_MSG
+                    );
+                }
 
-                await _unitOfWork.CropStageRepository.DeleteCropCropStageByStageIdAsync(stageId);
+                // Xóa giai đoạn
+                await _unitOfWork.CropStageRepository.RemoveAsync(stage);
 
+                // Lưu thay đổi
                 var result = await _unitOfWork.SaveChangesAsync();
 
                 if (result > 0)
-                    return new ServiceResult(Const.SUCCESS_DELETE_CODE, "Xóa stage giai đoạn thành công.");
+                {
+                    return new ServiceResult(
+                        Const.SUCCESS_DELETE_CODE,
+                        Const.SUCCESS_DELETE_MSG
+                    );
+                }
 
-                return new ServiceResult(Const.FAIL_DELETE_CODE, "Xóa stage thất bại.");
+                return new ServiceResult(
+                    Const.FAIL_DELETE_CODE,
+                    Const.FAIL_DELETE_MSG
+                );
             }
             catch (Exception ex)
             {
-                return new ServiceResult(Const.ERROR_EXCEPTION, ex.ToString());
+                return new ServiceResult(
+                    Const.ERROR_EXCEPTION,
+                    $"Lỗi khi xóa giai đoạn: {ex.Message}"
+                );
             }
         }
-
-        public async Task<IServiceResult> SoftDelete(int stageId)
+        public async Task<IServiceResult> SoftDeleteById(int stageId)
         {
             try
             {
+                // Tìm giai đoạn theo ID
                 var stage = await _unitOfWork.CropStageRepository.GetByIdAsync(stageId);
 
+                // Không tìm thấy hoặc đã xóa mềm
                 if (stage == null || stage.IsDeleted)
-                    return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Giai đoạn không tồn tại hoặc đã bị xóa.");
+                {
+                    return new ServiceResult(
+                        Const.WARNING_NO_DATA_CODE,
+                        Const.WARNING_NO_DATA_MSG
+                    );
+                }
 
+                // Gán trạng thái xoá mềm
                 stage.IsDeleted = true;
-                stage.UpdatedAt = DateTime.UtcNow;
+                stage.UpdatedAt = DateHelper.NowVietnamTime();
 
                 await _unitOfWork.CropStageRepository.UpdateAsync(stage);
+
+                // Lưu thay đổi
                 var result = await _unitOfWork.SaveChangesAsync();
 
                 if (result > 0)
-                    return new ServiceResult(Const.SUCCESS_DELETE_CODE, "Xóa mềm giai đoạn thành công.");
+                {
+                    return new ServiceResult(
+                        Const.SUCCESS_DELETE_CODE,
+                        Const.SUCCESS_DELETE_MSG
+                    );
+                }
 
-                return new ServiceResult(Const.FAIL_DELETE_CODE, "Xóa mềm thất bại.");
+                return new ServiceResult(
+                    Const.FAIL_DELETE_CODE,
+                    Const.FAIL_DELETE_MSG
+                );
             }
             catch (Exception ex)
             {
-                return new ServiceResult(Const.ERROR_EXCEPTION, ex.ToString());
+                return new ServiceResult(
+                    Const.ERROR_EXCEPTION,
+                    $"Lỗi khi xóa mềm giai đoạn: {ex.Message}"
+                );
             }
         }
+
 
     }
 }


### PR DESCRIPTION
## 🧩 Feature: CropProgress – Soft Delete & Hard Delete APIs

### 📌 Objective
Chuẩn hóa chức năng xóa mềm (IsDeleted) và xóa cứng cho entity `CropProgress`, theo mô hình đã áp dụng tại `UserAccountService`.  
Mục tiêu là thống nhất quy trình xóa trong toàn hệ thống và tăng khả năng bảo trì/kiểm soát dữ liệu.

---

### ✅ Key Changes
- [x] Thêm phương thức `DeleteById(Guid)` và `SoftDeleteById(Guid)` trong `CropProgressService`
- [x] Cập nhật controller:
  - `DELETE /api/CropProgresses/{id}` → gọi `DeleteById`
  - `PATCH /api/CropProgresses/{id}/soft-delete` → gọi `SoftDeleteById`
- [x] Cập nhật `ICropProgressRepository` và `CropProgressRepository`:
  - Thêm `SoftDelete(CropProgress)` và `PrepareRemove(CropProgress)`
- [x] Sử dụng `ServiceResult`, `DateHelper.NowVietnamTime`, chuẩn hóa xử lý lỗi và thông điệp

---

### 📎 Notes
- Không còn sử dụng `_context` trực tiếp trong service.
- Có thể tái sử dụng lại mẫu này cho `CropStage`, `CropSeason`, `Inventory`, v.v.

