### PR TITLE
feat(inventory): add soft & hard delete API in controller

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/InventoryController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/InventoryController.cs
@@ -46,5 +46,26 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             var result = await _inventoryService.CreateAsync(dto);
             return StatusCode(result.Status, result);
         }
+        /// <summary>
+        /// Xoá mềm tồn kho (IsDeleted = true)
+        /// </summary>
+        [HttpDelete("soft/{id}")]
+        [Authorize(Roles = "BusinessStaff,Admin")]
+        public async Task<IActionResult> SoftDelete(Guid id)
+        {
+            var result = await _inventoryService.SoftDeleteAsync(id);
+            return StatusCode(result.Status, result);
+        }
+
+        /// <summary>
+        /// Xoá thật tồn kho khỏi DB
+        /// </summary>
+        [HttpDelete("hard/{id}")]
+        [Authorize(Roles = "Admin")] // Xoá thật thì giới hạn cho Admin
+        public async Task<IActionResult> HardDelete(Guid id)
+        {
+            var result = await _inventoryService.HardDeleteAsync(id);
+            return StatusCode(result.Status, result);
+        }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IInventoryService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IInventoryService.cs
@@ -13,5 +13,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> GetAllAsync();
         Task<IServiceResult> GetByIdAsync(Guid id);
         Task<IServiceResult> CreateAsync(InventoryCreateDto dto);
+        Task<IServiceResult> SoftDeleteAsync(Guid id);
+        Task<IServiceResult> HardDeleteAsync(Guid id);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/InventoryService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/InventoryService.cs
@@ -94,5 +94,30 @@ namespace DakLakCoffeeSupplyChain.Services.Services
 
             return new ServiceResult(Const.SUCCESS_CREATE_CODE, "Tạo tồn kho thành công.", newInventory.InventoryId);
         }
+        public async Task<IServiceResult> SoftDeleteAsync(Guid id)
+        {
+            var entity = await _unitOfWork.Inventories.FindByIdAsync(id);
+            if (entity == null)
+                return new ServiceResult(Const.FAIL_DELETE_CODE, "Không tìm thấy tồn kho để xoá.");
+
+            entity.IsDeleted = true;
+            entity.UpdatedAt = DateTime.UtcNow;
+            _unitOfWork.Inventories.Update(entity);
+            await _unitOfWork.SaveChangesAsync();
+
+            return new ServiceResult(Const.SUCCESS_DELETE_CODE, "Xoá mềm tồn kho thành công.");
+        }
+
+        public async Task<IServiceResult> HardDeleteAsync(Guid id)
+        {
+            var entity = await _unitOfWork.Inventories.FindByIdAsync(id);
+            if (entity == null)
+                return new ServiceResult(Const.FAIL_DELETE_CODE, "Không tìm thấy tồn kho để xoá.");
+
+            _unitOfWork.Inventories.RemoveAsync(entity);
+            await _unitOfWork.SaveChangesAsync();
+
+            return new ServiceResult(Const.SUCCESS_DELETE_CODE, "Xoá thật tồn kho thành công.");
+        }
     }
 }


### PR DESCRIPTION
☕ Feature: Inventory – Delete (Soft & Hard Delete)
📌 Objective
Implement inventory deletion functionality in two modes:

Soft Delete: marks the inventory as deleted by setting IsDeleted = true

Hard Delete: permanently removes the inventory record from the database (restricted to Admins)

✅ Key Changes
Added new endpoints to InventoriesController: SoftDelete, HardDelete

Implemented new methods in InventoryService

Added role-based authorization checks (only Admins can perform hard delete)

Reused RemoveAsync() method from GenericRepository

🧱 Affected Files
InventoriesController.cs

IInventoryService.cs

InventoryService.cs

📁 Added
DELETE /api/inventories/soft/{id}

DELETE /api/inventories/hard/{id}

🧪 How to Test
Login with an appropriate role (BusinessManager or Admin) to obtain a valid JWT token

Send requests to the following endpoints:

Soft delete:
DELETE /api/inventories/soft/{inventoryId}

Hard delete:
DELETE /api/inventories/hard/{inventoryId}

Verify in the database:

Soft Delete: IsDeleted = true for the corresponding inventory record

Hard Delete: record is permanently removed from the Inventories table

🧪 Test Cases
 ✅ Valid deletion as BusinessManager using soft delete

 ❌ Attempt hard delete as non-Admin returns 403 Forbidden

 ✅ Successful hard delete as Admin removes record from DB

🔍 Notes
Entity Framework handles tracking state changes for deletion

Hard delete should be used with caution; prefer soft delete for data traceability

Frontend may need to refresh inventory list after deletion

🔗 Related
Modules: Inventory

Roles: Admin, BusinessManager









