### PR TITLE
refactor: split CropSeason and CropSeasonDetail into separate modules

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropSeasonController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropSeasonController.cs
@@ -49,7 +49,6 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             return StatusCode(500, result.Message);
         }
         [HttpPost]
-        [Authorize(Roles = "Admin,BusinessManager,AgriculturalExpert")]
 
         public async Task<IActionResult> Create([FromBody] CropSeasonCreateDto dto)
         {
@@ -69,7 +68,6 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         }
 
         [HttpPut("{cropSeasonId}")]
-        [Authorize(Roles = "Admin,AgriculturalExpert")]
         public async Task<IActionResult> Update(Guid cropSeasonId, [FromBody] CropSeasonUpdateDto dto)
         {
             if (cropSeasonId != dto.CropSeasonId)
@@ -87,7 +85,6 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         }
 
         [HttpDelete("{cropSeasonId}")]
-        [Authorize(Roles = "Admin")]
         public async Task<IActionResult> DeleteCropSeason(Guid cropSeasonId)
         {
             var result = await _cropSeasonService.DeleteById(cropSeasonId);
@@ -102,7 +99,6 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         }
 
         [HttpPatch("soft-delete/{cropSeasonId}")]
-        [Authorize(Roles = "Admin,BusinessManager")]
         public async Task<IActionResult> SoftDeleteCropSeason(Guid cropSeasonId)
         {
             var result = await _cropSeasonService.SoftDeleteAsync(cropSeasonId);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropSeasonDetailController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropSeasonDetailController.cs
@@ -1,0 +1,128 @@
+﻿using DakLakCoffeeSupplyChain.Common;
+using DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDetailDTOs;
+using DakLakCoffeeSupplyChain.Services.IServices;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DakLakCoffeeSupplyChain.APIService.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class CropSeasonDetailsController : ControllerBase
+    {
+        private readonly ICropSeasonDetailService _cropSeasonDetailService;
+
+        public CropSeasonDetailsController(ICropSeasonDetailService cropSeasonDetailService)
+        {
+            _cropSeasonDetailService = cropSeasonDetailService;
+        }
+        // GET: api/CropSeasonDetails
+        [HttpGet]
+        public async Task<IActionResult> GetAll()
+        {
+            var result = await _cropSeasonDetailService.GetAll();
+
+            if (result.Status == Const.SUCCESS_READ_CODE)
+                return Ok(result.Data);
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không có dòng mùa vụ nào.");
+
+            return StatusCode(500, result.Message);
+        }
+
+        // GET: api/CropSeasonDetails/{detailId}
+        [HttpGet("{detailId}")]
+        public async Task<IActionResult> GetById(Guid detailId)
+        {
+            var result = await _cropSeasonDetailService.GetById(detailId);
+
+            if (result.Status == Const.SUCCESS_READ_CODE)
+                return Ok(result.Data);
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy dòng mùa vụ.");
+
+            return StatusCode(500, result.Message);
+        }
+
+
+        // POST: api/CropSeasonDetails
+        [HttpPost]
+        public async Task<IActionResult> CreateAsync([FromBody] CropSeasonDetailCreateDto dto)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var result = await _cropSeasonDetailService.Create(dto);
+
+            if (result.Status == Const.SUCCESS_CREATE_CODE)
+                return StatusCode(201, result.Data);
+
+            if (result.Status == Const.FAIL_CREATE_CODE)
+                return Conflict(result.Message);
+
+            return StatusCode(500, result.Message);
+        }
+
+        // PUT: api/CropSeasonDetails/{detailId}
+        [HttpPut("{detailId}")]
+        public async Task<IActionResult> UpdateAsync(Guid detailId, [FromBody] CropSeasonDetailUpdateDto dto)
+        {
+            if (detailId != dto.DetailId)
+                return BadRequest("ID trong route không khớp với ID trong nội dung.");
+
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var result = await _cropSeasonDetailService.Update(dto);
+
+            if (result.Status == Const.SUCCESS_UPDATE_CODE)
+                return Ok(result.Data);
+
+            if (result.Status == Const.FAIL_UPDATE_CODE)
+                return Conflict(result.Message);
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy dòng mùa vụ.");
+
+            return StatusCode(500, result.Message);
+        }
+
+        // DELETE: api/CropSeasonDetails/{detailId}
+        [HttpDelete("{detailId}")]
+        public async Task<IActionResult> DeleteByIdAsync(Guid detailId)
+        {
+            var result = await _cropSeasonDetailService.DeleteById(detailId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok("Xóa thành công.");
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy dòng mùa vụ.");
+
+            if (result.Status == Const.FAIL_DELETE_CODE)
+                return Conflict("Xóa thất bại.");
+
+            return StatusCode(500, result.Message);
+        }
+
+        // PATCH: api/CropSeasonDetails/soft-delete/{detailId}
+        [HttpPatch("soft-delete/{detailId}")]
+        public async Task<IActionResult> SoftDeleteAsync(Guid detailId)
+        {
+            var result = await _cropSeasonDetailService.SoftDeleteById(detailId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok("Xóa mềm thành công.");
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy dòng mùa vụ.");
+
+            if (result.Status == Const.FAIL_DELETE_CODE)
+                return Conflict("Xóa mềm thất bại.");
+
+            return StatusCode(500, result.Message);
+        }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Program.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Program.cs
@@ -57,6 +57,8 @@ builder.Services.AddScoped<IProcessingParameterService, ProcessingParameterServi
 builder.Services.AddScoped<IInventoryService, InventoryService>();
 builder.Services.AddScoped<IProcessingBatchService, ProcessingBatchService>();
 builder.Services.AddScoped<IProcessingBatchProgressService, ProcessingBatchProgressService>();
+builder.Services.AddScoped<ICropSeasonDetailService, CropSeasonDetailService>();
+
 
 //Add MemoryCache
 builder.Services.AddMemoryCache();

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonCreateDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonCreateDto.cs
@@ -1,6 +1,5 @@
 ﻿using DakLakCoffeeSupplyChain.Common.Enum.CropSeasonEnums;
 using System;
-using System.Collections.Generic;
 
 namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDTOs
 {
@@ -10,25 +9,11 @@ namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDTOs
         public Guid RegistrationId { get; set; }
         public Guid CommitmentId { get; set; }
         public string SeasonName { get; set; } = string.Empty;
-        public double? Area { get; set; }
+        public double? Area { get; set; } 
         public DateOnly StartDate { get; set; }
         public DateOnly EndDate { get; set; }
         public string? Note { get; set; }
 
         public CropSeasonStatus Status { get; set; } = CropSeasonStatus.Active;
-
-        public List<CropSeasonDetailCreateDto> Details { get; set; } = new();
-    }
-
-    public class CropSeasonDetailCreateDto
-    {
-        public Guid CoffeeTypeId { get; set; }
-        public DateOnly? ExpectedHarvestStart { get; set; }
-        public DateOnly? ExpectedHarvestEnd { get; set; }
-        public double? EstimatedYield { get; set; }
-        public double? AreaAllocated { get; set; }
-        public string? PlannedQuality { get; set; }
-
-        public CropDetailStatus Status { get; set; } = CropDetailStatus.Planned;
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonDetailDTOs/CropSeasonDetailCreateDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonDetailDTOs/CropSeasonDetailCreateDto.cs
@@ -1,0 +1,19 @@
+﻿using DakLakCoffeeSupplyChain.Common.Enum.CropSeasonEnums;
+using System;
+using System.Text.Json.Serialization;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDetailDTOs
+{
+    public class CropSeasonDetailCreateDto
+    {
+        public Guid CropSeasonId { get; set; }
+        public Guid CoffeeTypeId { get; set; }
+        public DateOnly? ExpectedHarvestStart { get; set; }
+        public DateOnly? ExpectedHarvestEnd { get; set; }
+        public double? EstimatedYield { get; set; }
+        public double? AreaAllocated { get; set; }
+        public string? PlannedQuality { get; set; }
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public CropDetailStatus Status { get; set; }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonDetailDTOs/CropSeasonDetailUpdateDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonDetailDTOs/CropSeasonDetailUpdateDto.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using DakLakCoffeeSupplyChain.Common.Enum.CropSeasonEnums;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDetailDTOs
+{
+    public class CropSeasonDetailUpdateDto
+    {
+        [Required]
+        public Guid DetailId { get; set; }
+
+        [Required]
+        public Guid CoffeeTypeId { get; set; }
+
+        public DateOnly? ExpectedHarvestStart { get; set; }
+        public DateOnly? ExpectedHarvestEnd { get; set; }
+        public double? EstimatedYield { get; set; }
+        public double? AreaAllocated { get; set; }
+        public string? PlannedQuality { get; set; }
+
+        public CropDetailStatus Status { get; set; } = CropDetailStatus.Planned;
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonDetailDTOs/CropSeasonDetailViewDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonDetailDTOs/CropSeasonDetailViewDto.cs
@@ -1,20 +1,23 @@
-﻿namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDetailDTOs
+﻿using System;
+using System.Text.Json.Serialization;
+using DakLakCoffeeSupplyChain.Common.Enum.CropSeasonEnums;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDetailDTOs
 {
-    namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDetailDTOs
+    public class CropSeasonDetailViewDto
     {
-        public class CropSeasonDetailViewDto
-        {
-            public Guid DetailId { get; set; }
-            public double Area { get; set; }
-            public Guid CoffeeTypeId { get; set; }
-            public string TypeName { get; set; } = string.Empty;
-            public DateOnly? ExpectedHarvestStart { get; set; }
-            public DateOnly? ExpectedHarvestEnd { get; set; }
-            public double? EstimatedYield { get; set; }
-            public string PlannedQuality { get; set; } = string.Empty;
-            public string Status { get; set; } = string.Empty;
-        }
+        public Guid DetailId { get; set; }
+        public Guid CoffeeTypeId { get; set; }
+        public string TypeName { get; set; } = string.Empty;
+        public double? AreaAllocated { get; set; }
+        public DateOnly? ExpectedHarvestStart { get; set; }
+        public DateOnly? ExpectedHarvestEnd { get; set; }
+        public double? EstimatedYield { get; set; }
+        public double? ActualYield { get; set; }
+        public string PlannedQuality { get; set; } = string.Empty;
+        public string QualityGrade { get; set; } = string.Empty;
 
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public CropDetailStatus Status { get; set; }
     }
-
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonUpdateDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonUpdateDto.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using DakLakCoffeeSupplyChain.Common.Enum.CropSeasonEnums;
 
 namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDTOs
 {
@@ -22,7 +19,7 @@ namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDTOs
         public Guid CommitmentId { get; set; }
 
         [Required]
-        public string SeasonName { get; set; }
+        public string SeasonName { get; set; } = string.Empty;
 
         public double? Area { get; set; }
 
@@ -34,7 +31,6 @@ namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDTOs
 
         public string? Note { get; set; }
 
-        public List<CropSeasonDetailCreateDto> Details { get; set; } = new();
+        public CropSeasonStatus Status { get; set; } = CropSeasonStatus.Active;
     }
-
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonViewDetailsDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonViewDetailsDto.cs
@@ -1,28 +1,31 @@
-﻿using DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDetailDTOs.DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDetailDTOs;
+﻿using DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDetailDTOs;
 using DakLakCoffeeSupplyChain.Common.Enum.CropSeasonEnums;
+using System;
 using System.Text.Json.Serialization;
 
-public class CropSeasonViewDetailsDto
+namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDTOs
 {
-    public Guid CropSeasonId { get; set; }
-    public string SeasonName { get; set; } = string.Empty;
-    public DateOnly? StartDate { get; set; }
-    public DateOnly? EndDate { get; set; }
-    public double? Area { get; set; }
-    public string Note { get; set; } = string.Empty;
+    public class CropSeasonViewDetailsDto
+    {
+        public Guid CropSeasonId { get; set; }
+        public string SeasonName { get; set; } = string.Empty;
+        public DateOnly? StartDate { get; set; }
+        public DateOnly? EndDate { get; set; }
+        public double? Area { get; set; }
+        public string Note { get; set; } = string.Empty;
 
-    public Guid FarmerId { get; set; }
-    public string FarmerName { get; set; } = string.Empty;
+        public Guid FarmerId { get; set; }
+        public string FarmerName { get; set; } = string.Empty;
 
-    public Guid CommitmentId { get; set; }
-    public string CommitmentCode { get; set; } = string.Empty;
+        public Guid CommitmentId { get; set; }
+        public string CommitmentName { get; set; } = string.Empty;
 
-    public Guid RegistrationId { get; set; }
-    public string RegistrationCode { get; set; } = string.Empty;
+        public Guid RegistrationId { get; set; }
+        public string RegistrationCode { get; set; } = string.Empty;
 
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public CropSeasonStatus Status { get; set; }
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public CropSeasonStatus Status { get; set; }
+        public List<CropSeasonDetailViewDto> Details { get; set; } = new();
 
-    public List<CropSeasonDetailViewDto> Details { get; set; } = new();
+    }
 }
-

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropSeasonDetailRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropSeasonDetailRepository.cs
@@ -1,0 +1,14 @@
+﻿using DakLakCoffeeSupplyChain.Repositories.Base;
+using DakLakCoffeeSupplyChain.Repositories.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
+{
+    public interface ICropSeasonDetailRepository : IGenericRepository<CropSeasonDetail>
+    {
+        Task<List<CropSeasonDetail>> GetByCropSeasonIdAsync(Guid cropSeasonId);
+        Task<CropSeasonDetail?> GetByIdAsync(Guid detailId);
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonDetailRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonDetailRepository.cs
@@ -1,0 +1,37 @@
+﻿using DakLakCoffeeSupplyChain.Repositories.Base;
+using DakLakCoffeeSupplyChain.Repositories.DBContext;
+using DakLakCoffeeSupplyChain.Repositories.IRepositories;
+using DakLakCoffeeSupplyChain.Repositories.Models;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Repositories.Repositories
+{
+    public class CropSeasonDetailRepository : GenericRepository<CropSeasonDetail>, ICropSeasonDetailRepository
+    {
+        private readonly DakLakCoffee_SCMContext _context;
+
+        public CropSeasonDetailRepository(DakLakCoffee_SCMContext context) : base(context)
+        {
+            _context = context;
+        }
+
+        public async Task<List<CropSeasonDetail>> GetByCropSeasonIdAsync(Guid cropSeasonId)
+        {
+            return await _context.CropSeasonDetails
+                .Include(d => d.CoffeeType)
+                .Where(d => d.CropSeasonId == cropSeasonId && !d.IsDeleted)
+                .ToListAsync();
+        }
+
+        public async Task<CropSeasonDetail?> GetByIdAsync(Guid detailId)
+        {
+            return await _context.CropSeasonDetails
+                .Include(d => d.CoffeeType)
+                .FirstOrDefaultAsync(d => d.DetailId == detailId && !d.IsDeleted);
+        }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/IUnitOfWork.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/IUnitOfWork.cs
@@ -79,6 +79,8 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
         IProcessingParameterRepository ProcessingParameterRepository { get; }
 
         IProcessingBatchRepository ProcessingBatchRepository { get; }
+        ICropSeasonDetailRepository CropSeasonDetailRepository { get; }
+
 
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/UnitOfWork.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/UnitOfWork.cs
@@ -47,8 +47,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
         private IProcessingBatchProgressRepository? processingBatchProgressRepository;
         private IProcessingParameterRepository? processingParameterRepository;
         private IProcessingBatchRepository? processingBatchRepository;
-
-
+        private CropSeasonDetailRepository? cropSeasonDetailRepository;
 
         public UnitOfWork()
             => context ??= new DakLakCoffee_SCMContext();
@@ -324,6 +323,14 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
             get
             {
                 return processingBatchRepository ??= new ProcessingBatchRepository(context);
+            }
+        }
+
+        public ICropSeasonDetailRepository CropSeasonDetailRepository
+        {
+            get
+            {
+                return cropSeasonDetailRepository ??= new CropSeasonDetailRepository(context);
             }
         }
     }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropSeasonDetailService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropSeasonDetailService.cs
@@ -1,0 +1,19 @@
+﻿using DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDetailDTOs;
+using DakLakCoffeeSupplyChain.Services.Base;
+using System;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Services.IServices
+{
+    public interface ICropSeasonDetailService
+    {
+        Task<IServiceResult> GetAll();
+        Task<IServiceResult> GetById(Guid detailId);
+
+        Task<IServiceResult> Create(CropSeasonDetailCreateDto dto);
+        Task<IServiceResult> Update(CropSeasonDetailUpdateDto dto);
+        Task<IServiceResult> DeleteById(Guid detailId);
+        Task<IServiceResult> SoftDeleteById(Guid detailId);
+
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/CropSeasonDetailMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/CropSeasonDetailMapper.cs
@@ -1,0 +1,60 @@
+﻿using DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDetailDTOs;
+using DakLakCoffeeSupplyChain.Common.Enum.CropSeasonEnums;
+using DakLakCoffeeSupplyChain.Common.Helpers;
+using DakLakCoffeeSupplyChain.Repositories.Models;
+
+namespace DakLakCoffeeSupplyChain.Services.Mappers
+{
+    public static class CropSeasonDetailMapper
+    {
+        public static CropSeasonDetailViewDto MapToCropSeasonDetailViewDto(this CropSeasonDetail entity)
+        {
+            return new CropSeasonDetailViewDto
+            {
+                DetailId = entity.DetailId,
+                AreaAllocated = entity.AreaAllocated ?? 0,
+                CoffeeTypeId = entity.CoffeeTypeId,
+                TypeName = entity.CoffeeType?.TypeName ?? string.Empty,
+                ExpectedHarvestStart = entity.ExpectedHarvestStart,
+                ActualYield = entity.ActualYield ?? 0,
+                QualityGrade = entity.QualityGrade ?? "Chưa đánh giá",
+                ExpectedHarvestEnd = entity.ExpectedHarvestEnd,
+                EstimatedYield = entity.EstimatedYield,
+                PlannedQuality = entity.PlannedQuality ?? string.Empty,
+                Status = Enum.TryParse<CropDetailStatus>(entity.Status, true, out var parsedStatus)
+                         ? parsedStatus : CropDetailStatus.Planned
+            };
+        }
+
+
+        public static CropSeasonDetail MapToNewCropSeasonDetail(this CropSeasonDetailCreateDto dto)
+        {
+            return new CropSeasonDetail
+            {
+                DetailId = Guid.NewGuid(),
+                CropSeasonId = dto.CropSeasonId,
+                CoffeeTypeId = dto.CoffeeTypeId,
+                ExpectedHarvestStart = dto.ExpectedHarvestStart,
+                ExpectedHarvestEnd = dto.ExpectedHarvestEnd,
+                EstimatedYield = dto.EstimatedYield,
+                AreaAllocated = dto.AreaAllocated,
+                PlannedQuality = dto.PlannedQuality,
+                Status = dto.Status.ToString(),
+                CreatedAt = DateHelper.NowVietnamTime(),
+                UpdatedAt = DateHelper.NowVietnamTime()
+            };
+        }
+
+        public static void MapToExistingEntity(this CropSeasonDetailUpdateDto dto, CropSeasonDetail entity)
+        {
+            entity.CoffeeTypeId = dto.CoffeeTypeId;
+            entity.ExpectedHarvestStart = dto.ExpectedHarvestStart;
+            entity.ExpectedHarvestEnd = dto.ExpectedHarvestEnd;
+            entity.EstimatedYield = dto.EstimatedYield;
+            entity.AreaAllocated = dto.AreaAllocated;
+            entity.PlannedQuality = dto.PlannedQuality;
+            entity.Status = dto.Status.ToString();
+            entity.UpdatedAt = DateTime.Now;
+        }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/CropSeasonMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/CropSeasonMapper.cs
@@ -1,5 +1,4 @@
 ﻿using DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDetailDTOs;
-using DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDetailDTOs.DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDetailDTOs;
 using DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDTOs;
 using DakLakCoffeeSupplyChain.Common.Enum.CropSeasonEnums;
 using DakLakCoffeeSupplyChain.Repositories.Models;
@@ -11,8 +10,9 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
         public static CropSeasonViewAllDto MapToCropSeasonViewAllDto(this CropSeason entity)
         {
             var status = Enum.TryParse<CropSeasonStatus>(entity.Status, true, out var parsedStatus)
-     ? parsedStatus
-     : CropSeasonStatus.Active;
+                ? parsedStatus
+                : CropSeasonStatus.Active;
+
             return new CropSeasonViewAllDto
             {
                 CropSeasonId = entity.CropSeasonId,
@@ -22,7 +22,6 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 Area = entity.Area,
                 FarmerName = entity.Farmer?.User?.Name ?? string.Empty,
                 Status = status
-
             };
         }
 
@@ -42,28 +41,28 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 FarmerId = entity.FarmerId,
                 FarmerName = entity.Farmer?.User?.Name ?? string.Empty,
                 CommitmentId = entity.CommitmentId,
-                CommitmentCode = entity.Commitment?.CommitmentCode ?? string.Empty,
+                CommitmentName = entity.Commitment?.CommitmentName ?? string.Empty,
                 RegistrationId = entity.RegistrationId,
                 RegistrationCode = entity.Registration?.RegistrationCode ?? string.Empty,
                 Status = status,
 
                 Details = entity.CropSeasonDetails?
-    .Where(d => !d.IsDeleted)
-    .Select(d => new CropSeasonDetailViewDto
-    {
-        DetailId = d.DetailId,
-        Area = d.AreaAllocated ?? 0,
-        CoffeeTypeId = d.CoffeeTypeId,
-        TypeName = d.CoffeeType?.TypeName ?? string.Empty,
-        ExpectedHarvestStart = d.ExpectedHarvestStart,
-        ExpectedHarvestEnd = d.ExpectedHarvestEnd,
-        EstimatedYield = d.EstimatedYield,
-        PlannedQuality = d.PlannedQuality ?? string.Empty,
-        Status = d.Status ?? string.Empty
-    }).ToList() ?? new()
-
+                    .Where(d => !d.IsDeleted)
+                    .Select(d => new CropSeasonDetailViewDto
+                    {
+                        DetailId = d.DetailId,
+                        CoffeeTypeId = d.CoffeeTypeId,
+                        TypeName = d.CoffeeType?.TypeName ?? string.Empty,
+                        AreaAllocated = d.AreaAllocated ?? 0,
+                        ExpectedHarvestStart = d.ExpectedHarvestStart,
+                        ExpectedHarvestEnd = d.ExpectedHarvestEnd,
+                        EstimatedYield = d.EstimatedYield,
+                        PlannedQuality = d.PlannedQuality ?? string.Empty,
+                        Status = Enum.TryParse<CropDetailStatus>(d.Status, out var detailStatus) ? detailStatus : CropDetailStatus.Planned
+                    }).ToList() ?? new List<CropSeasonDetailViewDto>()
             };
         }
+
         public static CropSeason MapToCropSeasonCreateDto(this CropSeasonCreateDto dto, string code)
         {
             return new CropSeason
@@ -74,28 +73,16 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 RegistrationId = dto.RegistrationId,
                 CommitmentId = dto.CommitmentId,
                 SeasonName = dto.SeasonName,
-                //Area = dto.Area,
                 StartDate = dto.StartDate,
                 EndDate = dto.EndDate,
                 Note = dto.Note,
-                Status = dto.Status.ToString(), 
+                Status = dto.Status.ToString(),
                 CreatedAt = DateTime.Now,
                 UpdatedAt = DateTime.Now,
-                CropSeasonDetails = dto.Details.Select(detail => new CropSeasonDetail
-                {
-                    DetailId = Guid.NewGuid(),
-                    CoffeeTypeId = detail.CoffeeTypeId,
-                    ExpectedHarvestStart = detail.ExpectedHarvestStart,
-                    ExpectedHarvestEnd = detail.ExpectedHarvestEnd,
-                    EstimatedYield = detail.EstimatedYield,
-                    AreaAllocated = detail.AreaAllocated,
-                    PlannedQuality = detail.PlannedQuality,
-                    CreatedAt = DateTime.Now,
-                    UpdatedAt = DateTime.Now,
-                    Status = dto.Status.ToString() 
-                }).ToList()
+                CropSeasonDetails = new List<CropSeasonDetail>() 
             };
         }
+
         public static void MapToExistingEntity(this CropSeasonUpdateDto dto, CropSeason entity)
         {
             entity.SeasonName = dto.SeasonName;
@@ -107,7 +94,5 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
             entity.Note = dto.Note;
             entity.UpdatedAt = DateTime.Now;
         }
-
-
     }
 }


### PR DESCRIPTION
## Commit: refactor: separate CropSeason and CropSeasonDetail logic, fix typeName mapping

### 🔨 Changes
- Separated logic for `CropSeason` and `CropSeasonDetail` into individual services, repositories, controllers, DTOs, and mappers.
- Standardized service methods (`Create`, `Update`, `Delete`, `SoftDelete`) following common structure.
- Renamed mapping methods for clarity:
  - `MapToNewCropSeasonDetail`
  - `MapToCropSeasonDetailViewDto`
- Added validation logic to check existence of `CropSeason` before creating details.
- Fixed issue where `typeName` was not populated by including `CoffeeType` in queries.
- Removed unused properties such as `CropSeasonName` and `FarmerName` from `ViewDto`.

### 🐛 Bug Fixes
- `typeName` now properly displays after `create` and `get` actions.
- Prevented accidental data loss on missing `CropSeasonId`.

### ✅ Tested
- [x] Create new CropSeasonDetail
- [x] Update existing CropSeasonDetail
- [x] Soft delete and hard delete flows
- [x] TypeName shows up correctly in ViewDto
