### PR TITLE
feat(contract-delivery-batch): implement hard delete API with cascade removal of delivery items and role restriction

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractDeliveryBatchsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractDeliveryBatchsController.cs
@@ -99,6 +99,25 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             return StatusCode(500, result.Message);
         }
 
+        // DELETE api/<ContractDeliveryBatchsController>/{deliveryBatchId}
+        [HttpDelete("{deliveryBatchId}")]
+        [Authorize(Roles = "BusinessManager")]
+        public async Task<IActionResult> DeleteContractByIdAsync(Guid deliveryBatchId)
+        {
+            var result = await _contractDeliveryBatchService.DeleteContractDeliveryBatchById(deliveryBatchId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok("Xóa thành công.");
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy đợt giao hàng cần xóa.");
+
+            if (result.Status == Const.FAIL_DELETE_CODE)
+                return Conflict("Xóa thất bại.");
+
+            return StatusCode(500, result.Message);
+        }
+
         // PATCH: api/<ContractDeliveryBatchsController>/soft-delete/{deliveryBatchId}
         [HttpPatch("soft-delete/{deliveryBatchId}")]
         [Authorize(Roles = "BusinessManager")]

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractDeliveryBatchService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractDeliveryBatchService.cs
@@ -16,6 +16,8 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Create(ContractDeliveryBatchCreateDto contractDeliveryBatchDto, Guid userId);
 
+        Task<IServiceResult> DeleteContractDeliveryBatchById(Guid deliveryBatchId);
+
         Task<IServiceResult> SoftDeleteContractDeliveryBatchById(Guid deliveryBatchId);
     }
 }


### PR DESCRIPTION
## ☕ Feature: Hard Delete – ContractDeliveryBatch API

### 📌 Objective
Implement the API to **hard delete a contract delivery batch**, ensuring related delivery items are also removed. This feature supports the BusinessManager's ability to fully clean up erroneous or obsolete delivery batch data.

---

### ✅ Key Changes
- Implemented `DeleteContractDeliveryBatchById` service method with cascading deletion of related `ContractDeliveryItems`.
- Added `DELETE` endpoint in `ContractDeliveryBatchsController`, restricted to `BusinessManager` role.
- Integrated validation to check batch existence and associated items before deletion.

---

### 🧱 Affected Files
- `ContractDeliveryBatchsController.cs`
- `IContractDeliveryBatchService.cs`
- `ContractDeliveryBatchService.cs`

---

### 📁 Added
- _No new files added in this commit._

---

### 🧪 How to Test
1. **Login** as a `BusinessManager` and retrieve a valid JWT token.
2. Send a request to:
   - `DELETE /api/contractdeliverybatchs/{deliveryBatchId}`
   - Header: `Authorization: Bearer {token}`
3. Expected responses:
   - ✅ 200 OK: when deletion is successful
   - ❌ 404 Not Found: when deliveryBatchId does not exist
   - ❌ 409 Conflict: when deletion fails due to internal issue

---

### 🧪 Test Cases
- [x] ✅ Delete successfully with valid `deliveryBatchId`
- [x] ❌ Return 404 when batch does not exist or already deleted
- [x] ❌ Return 500 on unexpected exception
- [x] ❌ Return unauthorized if user does not have the correct role

---

### 🔍 Notes
- Restricted to `BusinessManager` role using `[Authorize]` attribute.
- Ensures consistency by manually removing associated `ContractDeliveryItems` before deleting batch.
- Uses `asNoTracking: false` to allow EF to track entities for deletion.

---

### 🔗 Related
- Modules: `ContractDeliveryBatch`, `ContractDeliveryItem`
- Roles: `BusinessManager`
