### PR TITLE
feat(processing-batch): support role-based access for viewing batches (Admin/Farmer)

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingBatchsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingBatchsController.cs
@@ -1,9 +1,11 @@
 ﻿using DakLakCoffeeSupplyChain.Common;
 using DakLakCoffeeSupplyChain.Services.IServices;
 using DakLakCoffeeSupplyChain.Services.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Query;
+using System.Security.Claims;
 
 namespace DakLakCoffeeSupplyChain.APIService.Controllers
 {
@@ -22,29 +24,21 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
         [HttpGet]
         [EnableQuery]
-        //public async Task<IActionResult> GetAll()
-        //{
-        //    var result = await _processingbatchservice.GetAll();
-
-        //    if (result.Status == Const.SUCCESS_READ_CODE)
-        //        return Ok(result.Data);
-
-        //    if (result.Status == Const.WARNING_NO_DATA_CODE)
-        //        return NotFound(result.Message);
-
-        //    return StatusCode(500, result.Message);
-        //}
+        
+        [Authorize(Roles = "Farmer,Admin")]
         public async Task<IActionResult> GetAll()
         {
             var userIdStr = User.FindFirst("userId")?.Value
-                         ?? User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+                         ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
 
             if (!Guid.TryParse(userIdStr, out var userId))
             {
                 return BadRequest("Không thể lấy userId từ token.");
             }
 
-            var result = await _processingbatchservice.GetAllByUserId(userId);
+            var isAdmin = User.IsInRole("Admin");
+
+            var result = await _processingbatchservice.GetAllByUserId(userId, isAdmin);
 
             if (result.Status == Const.SUCCESS_READ_CODE)
                 return Ok(result.Data);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingBatchService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingBatchService.cs
@@ -10,6 +10,6 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
     public interface IProcessingBatchService
     {
         Task<IServiceResult> GetAll();
-        Task<IServiceResult> GetAllByUserId(Guid userId);
+        Task<IServiceResult> GetAllByUserId(Guid userId, bool isAdmin = false);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProcessingBatchService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProcessingBatchService.cs
@@ -1,5 +1,6 @@
 ﻿using DakLakCoffeeSupplyChain.Common;
 using DakLakCoffeeSupplyChain.Common.DTOs.ProcessingBatchDTOs;
+using DakLakCoffeeSupplyChain.Repositories.Models;
 using DakLakCoffeeSupplyChain.Repositories.UnitOfWork;
 using DakLakCoffeeSupplyChain.Services.Base;
 using DakLakCoffeeSupplyChain.Services.IServices;
@@ -43,57 +44,40 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 dtoList
             );
         }
-        //public async Task<IServiceResult> GetAllByUserId(string userId)
-        //{
-        //    if (!Guid.TryParse(userId, out var userGuid))
-        //    {
-        //        return new ServiceResult(Const.WARNING_NO_DATA_CODE, "UserId không hợp lệ", null);
-        //    }
-
-        //    // Lấy farmer duy nhất theo userId
-        //    var farmer = await _unitOfWork.FarmerRepository.FindByUserIdAsync(userGuid);
-        //    if (farmer == null)
-        //    {
-        //        return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Không tìm thấy Farmer tương ứng.", new List<ProcessingBatchViewDto>());
-        //    }
-
-        //    // Lấy các batch thuộc farmerId
-        //    var batches = await _unitOfWork.ProcessingBatchRepository
-        //        .GetQueryable()
-        //        .Include(pb => pb.CropSeason)
-        //        .Include(pb => pb.Farmer).ThenInclude(f => f.User)
-        //        .Include(pb => pb.Method)
-        //        .Include(pb => pb.ProcessingBatchProgresses)
-        //        .Where(pb => pb.FarmerId == farmer.FarmerId && !pb.IsDeleted)
-        //        .ToListAsync();
-
-        //    if (!batches.Any())
-        //    {
-        //        return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Không có dữ liệu ProcessingBatch.", new List<ProcessingBatchViewDto>());
-        //    }
-
-        //    var dtoList = batches.Select(b => b.MapToProcessingBatchViewDto()).ToList();
-
-        //    return new ServiceResult(Const.SUCCESS_READ_CODE, Const.SUCCESS_READ_MSG, dtoList);
-        //}
-        public async Task<IServiceResult> GetAllByUserId(Guid userId)
+        public async Task<IServiceResult> GetAllByUserId(Guid userId, bool isAdmin = false)
         {
-            // Lấy farmer duy nhất theo userId
-            var farmer = await _unitOfWork.FarmerRepository.FindByUserIdAsync(userId);
-            if (farmer == null)
-            {
-                return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Không tìm thấy Farmer tương ứng.", new List<ProcessingBatchViewDto>());
-            }
+            List<ProcessingBatch> batches;
 
-            // Lấy các batch thuộc farmerId
-            var batches = await _unitOfWork.ProcessingBatchRepository
-                .GetQueryable()
-                .Include(pb => pb.CropSeason)
-                .Include(pb => pb.Farmer).ThenInclude(f => f.User)
-                .Include(pb => pb.Method)
-                .Include(pb => pb.ProcessingBatchProgresses)
-                .Where(pb => pb.FarmerId == farmer.FarmerId && !pb.IsDeleted)
-                .ToListAsync();
+            if (isAdmin)
+            {
+                // Admin xem tất cả
+                batches = await _unitOfWork.ProcessingBatchRepository
+                    .GetQueryable()
+                    .Include(pb => pb.CropSeason)
+                    .Include(pb => pb.Farmer).ThenInclude(f => f.User)
+                    .Include(pb => pb.Method)
+                    .Include(pb => pb.ProcessingBatchProgresses)
+                    .Where(pb => !pb.IsDeleted)
+                    .ToListAsync();
+            }
+            else
+            {
+                // Farmer chỉ xem batch của chính họ
+                var farmer = await _unitOfWork.FarmerRepository.FindByUserIdAsync(userId);
+                if (farmer == null)
+                {
+                    return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Không tìm thấy Farmer tương ứng.", new List<ProcessingBatchViewDto>());
+                }
+
+                batches = await _unitOfWork.ProcessingBatchRepository
+                    .GetQueryable()
+                    .Include(pb => pb.CropSeason)
+                    .Include(pb => pb.Farmer).ThenInclude(f => f.User)
+                    .Include(pb => pb.Method)
+                    .Include(pb => pb.ProcessingBatchProgresses)
+                    .Where(pb => pb.FarmerId == farmer.FarmerId && !pb.IsDeleted)
+                    .ToListAsync();
+            }
 
             if (!batches.Any())
             {
@@ -101,10 +85,8 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             }
 
             var dtoList = batches.Select(b => b.MapToProcessingBatchViewDto()).ToList();
-
             return new ServiceResult(Const.SUCCESS_READ_CODE, Const.SUCCESS_READ_MSG, dtoList);
         }
-
 
     }
 }


### PR DESCRIPTION
## ☕ Feature: View ProcessingBatch list based on user role

---

### 📌 Objective
Update the `GetAll` API in `ProcessingBatch` to support:
- 👩‍💼 **Admin**: can view all processing batches in the system
- 👨‍🌾 **Farmer**: can only view their own batches (filtered by `farmerId` derived from `userId` in the token)

---

### ✅ Key Changes
- Added `isAdmin` parameter to `GetAllByUserId(Guid userId, bool isAdmin = false)`
- If `isAdmin == true`, fetch all non-deleted `ProcessingBatch` records
- If `isAdmin == false`, map `userId → farmerId` and filter batches accordingly
- Updated controller to detect role using `User.IsInRole("Admin")`

---

### 🧱 Affected Files
- `ProcessingBatchController.cs`
- `IProcessingBatchService.cs`
- `ProcessingBatchService.cs`

---

### 🧪 Test Cases
- [x] ✅ Admin calls `GET /api/processingbatches` → receives all batches
- [x] ✅ Farmer calls the same endpoint → receives only their own batches
- [x] ❌ Missing or invalid `userId` in token → returns `400 Bad Request`
- [x] ✅ No data available → returns `404 Not Found`

---

### 🔍 Notes
- Ensure frontend includes valid JWT token with `userId` claim
- Future enhancements could include pagination, status filtering, or crop season filtering
