### PR TITLE
feat: retrieve UserID from CropSeason via linked Farmer

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonCreateDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonCreateDto.cs
@@ -5,7 +5,7 @@ namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDTOs
 {
     public class CropSeasonCreateDto
     {
-        public Guid FarmerId { get; set; }
+        //public Guid FarmerId { get; set; }
         public Guid RegistrationId { get; set; }
         public Guid CommitmentId { get; set; }
         public string SeasonName { get; set; } = string.Empty;

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonDetailDTOs/CropSeasonDetailViewDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonDetailDTOs/CropSeasonDetailViewDto.cs
@@ -6,6 +6,8 @@ namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDetailDTOs
 {
     public class CropSeasonDetailViewDto
     {
+        public Guid FarmerId { get; set; }
+        public string FarmerName { get; set; } = string.Empty;
         public Guid DetailId { get; set; }
         public Guid CoffeeTypeId { get; set; }
         public string TypeName { get; set; } = string.Empty;

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonUpdateDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonUpdateDto.cs
@@ -9,8 +9,8 @@ namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDTOs
         [Required]
         public Guid CropSeasonId { get; set; }
 
-        [Required]
-        public Guid FarmerId { get; set; }
+        //[Required]
+        //public Guid FarmerId { get; set; }
 
         [Required]
         public Guid RegistrationId { get; set; }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonViewAllDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonViewAllDto.cs
@@ -11,6 +11,8 @@ namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDTOs
         public DateOnly? StartDate { get; set; }
         public DateOnly? EndDate { get; set; }
         public double? Area { get; set; }
+        public Guid FarmerId { get; set; }
+
         public string FarmerName { get; set; } = string.Empty;
 
         [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonRepository.cs
@@ -31,6 +31,17 @@ public class CropSeasonRepository : GenericRepository<CropSeason>, ICropSeasonRe
             .FirstOrDefaultAsync(c => c.CropSeasonId == cropSeasonId && !c.IsDeleted);
     }
 
+    public async Task<List<CropSeason>> GetCropSeasonsByUserIdAsync(Guid userId)
+    {
+        return await _context.CropSeasons
+            .AsNoTracking()
+            .Where(c => !c.IsDeleted && c.Farmer.UserId == userId)
+            .Include(c => c.Farmer)
+                .ThenInclude(f => f.User)
+            .OrderBy(c => c.StartDate)
+            .ToListAsync();
+    }
+
     public async Task<int> CountByYearAsync(int year)
     {
         return await _context.CropSeasons

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/UnitOfWork.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/UnitOfWork.cs
@@ -47,7 +47,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
         private IProcessingBatchProgressRepository? processingBatchProgressRepository;
         private IProcessingParameterRepository? processingParameterRepository;
         private IProcessingBatchRepository? processingBatchRepository;
-        private CropSeasonDetailRepository? cropSeasonDetailRepository;
+        private ICropSeasonDetailRepository? cropSeasonDetailRepository;
         private IInventoryLogRepository? inventoryLogRepository;
         private IExpertAdviceRepository? expertAdviceRepository;
         private IAgriculturalExpertRepository? agriculturalExpertRepository;

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropSeasonService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/ICropSeasonService.cs
@@ -1,20 +1,19 @@
-﻿using DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDTOs;
+﻿using DakLakCoffeeSupplyChain.Common;
+using DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDTOs;
 using DakLakCoffeeSupplyChain.Services.Base;
+using System;
+using System.Threading.Tasks;
 
 namespace DakLakCoffeeSupplyChain.Services.IServices
 {
     public interface ICropSeasonService
     {
         Task<IServiceResult> GetAll();
-
-        Task<IServiceResult> GetById(Guid id);
-
-        Task<IServiceResult> Create(CropSeasonCreateDto dto);
-
+        Task<IServiceResult> GetAllByUserId(Guid userId);
+        Task<IServiceResult> GetById(Guid cropSeasonId);
+        Task<IServiceResult> Create(CropSeasonCreateDto dto, Guid userId);
         Task<IServiceResult> Update(CropSeasonUpdateDto dto);
-
         Task<IServiceResult> DeleteById(Guid cropSeasonId);
-
         Task<IServiceResult> SoftDeleteAsync(Guid cropSeasonId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/CropSeasonDetailMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/CropSeasonDetailMapper.cs
@@ -22,9 +22,13 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 EstimatedYield = entity.EstimatedYield,
                 PlannedQuality = entity.PlannedQuality ?? string.Empty,
                 Status = Enum.TryParse<CropDetailStatus>(entity.Status, true, out var parsedStatus)
-                         ? parsedStatus : CropDetailStatus.Planned
+                            ? parsedStatus : CropDetailStatus.Planned,
+
+                FarmerId = entity.CropSeason?.FarmerId ?? Guid.Empty,
+                FarmerName = entity.CropSeason?.Farmer?.User?.Name ?? "Không rõ"
             };
         }
+
 
 
         public static CropSeasonDetail MapToNewCropSeasonDetail(this CropSeasonDetailCreateDto dto)

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/CropSeasonMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/CropSeasonMapper.cs
@@ -21,6 +21,7 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 EndDate = entity.EndDate,
                 Area = entity.Area,
                 FarmerName = entity.Farmer?.User?.Name ?? string.Empty,
+                FarmerId = entity.FarmerId,
                 Status = status
             };
         }
@@ -63,13 +64,13 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
             };
         }
 
-        public static CropSeason MapToCropSeasonCreateDto(this CropSeasonCreateDto dto, string code)
+        public static CropSeason MapToCropSeasonCreateDto(this CropSeasonCreateDto dto, string code, Guid farmerId)
         {
             return new CropSeason
             {
                 CropSeasonId = Guid.NewGuid(),
                 CropSeasonCode = code,
-                FarmerId = dto.FarmerId,
+                FarmerId = farmerId,
                 RegistrationId = dto.RegistrationId,
                 CommitmentId = dto.CommitmentId,
                 SeasonName = dto.SeasonName,
@@ -79,7 +80,7 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 Status = dto.Status.ToString(),
                 CreatedAt = DateTime.Now,
                 UpdatedAt = DateTime.Now,
-                CropSeasonDetails = new List<CropSeasonDetail>() 
+                CropSeasonDetails = new List<CropSeasonDetail>()
             };
         }
 
@@ -92,6 +93,7 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
             entity.StartDate = dto.StartDate;
             entity.EndDate = dto.EndDate;
             entity.Note = dto.Note;
+            entity.Status = dto.Status.ToString();
             entity.UpdatedAt = DateTime.Now;
         }
     }


### PR DESCRIPTION
### 🚀 Feature: Retrieve `UserID` from `CropSeason` via `Farmer`

This PR adds logic to extract and utilize `UserID` for a given `CropSeason` by resolving the relationship:


### ✅ Changes:
- Add `CreatedBy` or `UserID` tracking to `CropSeason`
- Ensure backend can filter crop seasons by `UserID`
- Validate `UserID` consistency across CropSeason and CropSeasonDetail

### 📌 Notes:
- This enables per-user access control to crop seasons
- Useful for implementing "My Crop Seasons" feature on frontend

### 🧪 Testing
- [x] Created crop seasons with known `Farmer → UserID` link
- [x] Verified that returned data includes `UserID`
- [x] Backend API correctly filters by `UserID`
