### PR TITLE
refactor(business-buyer): improve update API with permission check, validation, and rename delete methods for clarity

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessBuyersController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessBuyersController.cs
@@ -99,7 +99,7 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
         // PUT api/<BusinessBuyersController>/{buyerId}
         [HttpPut("{buyerId}")]
-        public async Task<IActionResult> UpdateRoleAsync(Guid buyerId, [FromBody] BusinessBuyerUpdateDto businessBuyerDto)
+        public async Task<IActionResult> UpdateBusinessBuyerAsync(Guid buyerId, [FromBody] BusinessBuyerUpdateDto businessBuyerDto)
         {
             // So sánh route id với dto id để đảm bảo tính nhất quán
             if (buyerId != businessBuyerDto.BuyerId)
@@ -108,7 +108,19 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
-            var result = await _businessBuyerService.Update(businessBuyerDto);
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
+            var result = await _businessBuyerService.Update(businessBuyerDto, userId);
 
             if (result.Status == Const.SUCCESS_UPDATE_CODE)
                 return Ok(result.Data);
@@ -124,9 +136,9 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
         // DELETE api/<BusinessBuyersController>/{buyerId}
         [HttpDelete("{buyerId}")]
-        public async Task<IActionResult> DeleteRoleByIdAsync(Guid buyerId)
+        public async Task<IActionResult> DeleteBusinessBuyerByIdAsync(Guid buyerId)
         {
-            var result = await _businessBuyerService.DeleteById(buyerId);
+            var result = await _businessBuyerService.DeleteBusinessBuyerById(buyerId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok("Xóa thành công.");
@@ -144,7 +156,7 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [HttpPatch("soft-delete/{buyerId}")]
         public async Task<IActionResult> SoftDeleteBusinessBuyerByIdAsync(Guid buyerId)
         {
-            var result = await _businessBuyerService.SoftDeleteById(buyerId);
+            var result = await _businessBuyerService.SoftDeleteBusinessBuyerById(buyerId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok("Xóa mềm thành công.");

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessBuyerService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessBuyerService.cs
@@ -16,10 +16,10 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Create(BusinessBuyerCreateDto businessBuyerDto, Guid userId);
 
-        Task<IServiceResult> Update(BusinessBuyerUpdateDto businessBuyerDto);
+        Task<IServiceResult> Update(BusinessBuyerUpdateDto businessBuyerDto, Guid userId);
 
-        Task<IServiceResult> DeleteById(Guid buyerId);
+        Task<IServiceResult> DeleteBusinessBuyerById(Guid buyerId);
 
-        Task<IServiceResult> SoftDeleteById(Guid buyerId);
+        Task<IServiceResult> SoftDeleteBusinessBuyerById(Guid buyerId);
     }
 }


### PR DESCRIPTION
## ☕ Feature: Update Business Buyer API & Rename Delete Methods

### 📌 Objective
Refactor the `UpdateBusinessBuyer` API to improve permission checking, validation, and maintain consistency with project conventions.  
Also rename delete methods for clarity and alignment with naming standards.

---

### ✅ Key Changes
- Add ownership check: only allow BusinessManagers to update their own buyers (`CreatedBy == ManagerId`).
- Validate `TaxId` uniqueness only if it’s changed.
- Refactor `MapToUpdateBusinessBuyer()` for cleaner field mapping.
- Rename:
  - `DeleteById` → `DeleteBusinessBuyerById`
  - `SoftDeleteById` → `SoftDeleteBusinessBuyerById`

---

### 🧱 Affected Files
- `BusinessBuyersController.cs`
- `IBusinessBuyerService.cs`
- `BusinessBuyerService.cs`
- `BusinessBuyerUpdateDto.cs`
- `BusinessBuyerMapper.cs`

---

### 📁 Added
- *(No new files added in this commit)*

---

### 🧪 How to Test
1. **Login** using a `BusinessManager` account to retrieve JWT token.
2. Send a request to the update endpoint:
   - `PUT /api/businessbuyers/{buyerId}`
   - Header: `Authorization: Bearer {token}`
3. Example request body:
```json
{
  "BuyerId": "GUID_HERE",
  "CompanyName": "New Company Ltd.",
  "TaxId": "1234567890",
  "ContactPerson": "John Doe",
  "Position": "CEO",
  "CompanyAddress": "123 Sample Street",
  "Email": "john@company.com",
  "PhoneNumber": "0901234567",
  "Website": "https://company.com"
}
```

---

### 🧪 Test Cases
- ✅ **Successfully update buyer** with valid data and correct ownership.
- ❌ **Reject update** when `TaxId` already exists for another buyer of the same creator.
- ❌ **Reject update** if current user is not the creator of the buyer.
- ❌ **Reject update** when `BuyerId` in route does not match the DTO.
- ✅ **Ensure renamed delete methods** are still properly functional.

---

### 🔍 Notes
- `ManagerId` is resolved from `userId` in JWT token (`User.GetUserId()` → `BusinessManager.ManagerId`).
- Role check is enforced via `[Authorize(Roles = "BusinessManager")]`.
- No breaking changes or DB migrations included in this update.

---

### 🔗 Related
- **Modules**: `BusinessBuyer`
- **Roles**: `BusinessManager`
