### PR TITLE
refactor(business-manager): enforce role-based access in SoftDelete API with self-check for BusinessManager

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessManagersController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessManagersController.cs
@@ -92,7 +92,7 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         // PUT api/<BusinessManagersController>/{managerId}
         [HttpPut("{managerId}")]
         [Authorize(Roles = "Admin,BusinessManager")]
-        public async Task<IActionResult> UpdateRoleAsync(Guid managerId, [FromBody] BusinessManagerUpdateDto businessManagerDto)
+        public async Task<IActionResult> UpdateBusinessManagerAsync(Guid managerId, [FromBody] BusinessManagerUpdateDto businessManagerDto)
         {
             // So sánh route id với dto id để đảm bảo tính nhất quán
             if (managerId != businessManagerDto.ManagerId)
@@ -118,9 +118,9 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         // DELETE api/<BusinessManagersController>/{managerId}
         [HttpDelete("{managerId}")]
         [Authorize(Roles = "Admin")]
-        public async Task<IActionResult> DeleteRoleByIdAsync(Guid managerId)
+        public async Task<IActionResult> DeleteBusinessManagerByIdAsync(Guid managerId)
         {
-            var result = await _businessManagerService.DeleteById(managerId);
+            var result = await _businessManagerService.DeleteBusinessManagerById(managerId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok("Xóa thành công.");
@@ -139,7 +139,20 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [Authorize(Roles = "Admin,BusinessManager")]
         public async Task<IActionResult> SoftDeleteBusinessManagerByIdAsync(Guid managerId)
         {
-            var result = await _businessManagerService.SoftDeleteById(managerId);
+            Guid userId;
+            string userRole;
+
+            try
+            {
+                userId = User.GetUserId();
+                userRole = User.GetRole();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId hoặc role từ token.");
+            }
+
+            var result = await _businessManagerService.SoftDeleteBusinessManagerById(managerId, userId, userRole);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok("Xóa mềm thành công.");

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessManagerService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessManagerService.cs
@@ -19,8 +19,8 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Update(BusinessManagerUpdateDto businessManagerDto);
 
-        Task<IServiceResult> DeleteById(Guid managerId);
+        Task<IServiceResult> DeleteBusinessManagerById(Guid managerId);
 
-        Task<IServiceResult> SoftDeleteById(Guid managerId);
+        Task<IServiceResult> SoftDeleteBusinessManagerById(Guid managerId, Guid userId, string userRole);
     }
 }


### PR DESCRIPTION
## ☕ Feature: BusinessManager – Soft Delete API Permission Check

### 📌 Objective
Enforce role-based access control in the **Soft Delete BusinessManager API**, allowing only `Admin` to delete any manager and restricting `BusinessManager` to soft-delete only themselves.

---

### ✅ Key Changes
- Refactor `SoftDeleteById` service to include `userId` and `userRole` parameters
- Implement self-access validation logic for `BusinessManager` role
- Enhance response clarity with consistent status handling for deleted/nonexistent records

---

### 🧱 Affected Files
- `BusinessManagersController.cs`
- `IBusinessManagerService.cs`
- `BusinessManagerService.cs`

---

### 📁 Added
- *(No new files added)*

---

### 🧪 How to Test
1. **Login** with a valid JWT token for a user with `BusinessManager` or `Admin` role
2. Send a `PATCH` request to:
   - `PATCH /api/businessmanagers/soft-delete/{managerId}`
   - Header: `Authorization: Bearer {token}`
3. Ensure:
   - `Admin` can delete any manager
   - `BusinessManager` can only delete their own record

---

### 🧪 Test Cases
- [x] ✅ Admin soft-deletes any BusinessManager successfully  
- [x] ✅ BusinessManager soft-deletes their own account successfully  
- [x] ❌ BusinessManager attempts to delete another manager → blocked with permission error  
- [x] ✅ Soft-deleting a non-existent manager ID returns "not found"  

---

### 🔍 Notes
- Used `if...else` structure intentionally for readability and clarity for team members working across frontend/backend  
- `IsDeleted` check not used in query to allow soft-deleting even if previously deleted  
- No DTO changes required, only service and controller logic  

---

### 🔗 Related
- Modules: `BusinessManager`
- Roles: `Admin`, `BusinessManager`
