### PR TITLE
refactor(business-buyer): enforce access control in GetById API to ensure buyer belongs to current BusinessManager

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessBuyersController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessBuyersController.cs
@@ -54,7 +54,19 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [HttpGet("{buyerId}")]
         public async Task<IActionResult> GetById(Guid buyerId)
         {
-            var result = await _businessBuyerService.GetById(buyerId);
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
+            var result = await _businessBuyerService.GetById(buyerId, userId);
 
             if (result.Status == Const.SUCCESS_READ_CODE)
                 return Ok(result.Data);              // Trả object chi tiết
@@ -172,7 +184,19 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
         private async Task<bool> BusinessBuyerExistsAsync(Guid buyerId)
         {
-            var result = await _businessBuyerService.GetById(buyerId);
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return false;
+            }
+
+            var result = await _businessBuyerService.GetById(buyerId, userId);
 
             return result.Status == Const.SUCCESS_READ_CODE;
         }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessBuyerService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessBuyerService.cs
@@ -12,7 +12,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
     {
         Task<IServiceResult> GetAll(Guid userId);
 
-        Task<IServiceResult> GetById(Guid buyerId);
+        Task<IServiceResult> GetById(Guid buyerId, Guid userId);
 
         Task<IServiceResult> Create(BusinessBuyerCreateDto businessBuyerDto, Guid userId);
 

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/BusinessBuyerService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/BusinessBuyerService.cs
@@ -80,11 +80,30 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             }
         }
 
-        public async Task<IServiceResult> GetById(Guid buyerId)
+        public async Task<IServiceResult> GetById(Guid buyerId, Guid userId)
         {
+            // Tìm BusinessManager tương ứng với userId
+            var manager = await _unitOfWork.BusinessManagerRepository.GetByIdAsync(
+                predicate: m => 
+                   m.UserId == userId && 
+                   m.IsDeleted != true,
+                asNoTracking: true
+            );
+
+            if (manager == null)
+            {
+                return new ServiceResult(
+                    Const.WARNING_NO_DATA_CODE,
+                    "Không tìm thấy BusinessManager tương ứng với tài khoản."
+                );
+            }
+
             // Tìm buyer theo ID
             var businessBuyer = await _unitOfWork.BusinessBuyerRepository.GetByIdAsync(
-                predicate: bb => bb.BuyerId == buyerId,
+                predicate: bb => 
+                   bb.BuyerId == buyerId && 
+                   bb.CreatedBy == manager.ManagerId &&
+                   bb.IsDeleted != true,
                 include: query => query
                    .Include(bb => bb.CreatedByNavigation),
                 asNoTracking: true


### PR DESCRIPTION
## ☕ Feature: BusinessBuyer – Secure GetById API with ownership check

### 📌 Objective
Enhance the `GetById` API of BusinessBuyer by enforcing ownership validation. This ensures that only the BusinessManager who created the buyer can retrieve its details, preventing unauthorized access across different businesses.

---

### ✅ Key Changes
- Refactored `GetById` in `BusinessBuyerService` to verify the buyer belongs to the current BusinessManager via `CreatedBy == ManagerId`.
- Applied `IsDeleted != true` checks for both BusinessManager and BusinessBuyer entities.
- Updated controller to extract `userId` from token and pass it to the service layer.
- Added `BusinessBuyerExistsAsync(...)` in controller to encapsulate access control and existence check logic.

---

### 🧱 Affected Files
- `BusinessBuyersController.cs`
- `IBusinessBuyerService.cs`
- `BusinessBuyerService.cs`

---

### 🧪 How to Test
1. **Login** as a BusinessManager to obtain a valid JWT token.
2. Send a GET request to:
   - `GET /api/businessbuyers/{buyerId}`
   - Include header: `Authorization: Bearer {token}`
3. Verify the API behavior in different scenarios.

---

### 🧪 Test Cases
- [x] ✅ Get buyer that belongs to current BusinessManager → returns **200 OK**
- [x] ❌ Get buyer created by another BusinessManager → returns **404 Not Found**
- [x] ❌ Get buyer that has been soft-deleted → returns **404 Not Found**
- [x] ✅ Valid token and buyer → returns correct detail DTO

---

### 🔍 Notes
- Follows multi-tenant architecture by ensuring data isolation between businesses.
- Prevents unauthorized access even if `buyerId` is known.
- Reuses existing `CreatedBy` and `IsDeleted` fields for permission checks.
- 💡 Consider refactoring access validation into a shared service/helper for reuse in Update/Delete APIs.

---

### 🔗 Related
- Modules: `BusinessBuyer`
- Roles: `BusinessManager`
