### PR TITLE
refactor(crop-season): improve code generation and enrich season deta…

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropSeasonRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropSeasonRepository.cs
@@ -18,6 +18,8 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
         Task DeleteCropSeasonDetailsBySeasonIdAsync(Guid cropSeasonId);
 
         Task<bool> ExistsAsync(Expression<Func<CropSeason, bool>> predicate);
+        IQueryable<CropSeason> GetQuery();
+
 
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonRepository.cs
@@ -74,6 +74,9 @@ public class CropSeasonRepository : GenericRepository<CropSeason>, ICropSeasonRe
     {
         return await _context.CropSeasons.AnyAsync(predicate);
     }
-
+    public IQueryable<CropSeason> GetQuery()
+    {
+        return _context.CropSeasons.AsQueryable();
+    }
 
 }


### PR DESCRIPTION
## ✨ Enhance CropSeason Code Generation & Post-Creation Data Enrichment

### 🔧 Modified Files
- `ICropSeasonRepository.cs`
- `CropSeasonRepository.cs`
- `CodeGenerator.cs`
- `CropSeasonService.cs`

### 📝 Description
This commit improves the creation logic and return payload for crop seasons:

- ✅ **Code Generation Enhancement**  
  Updated `CodeGenerator.GenerateCropSeasonCodeAsync()` to avoid duplicate season codes by accurately counting existing records by year.

- 🔄 **Repository Updates**  
  Extended repository includes to fetch:
  - `CultivationRegistration` (for `registrationCode`)
  - `FarmingCommitment` (for `commitmentName`)
  - `Farmer.User` (for `farmerName`)

- 📦 **Service Response Enrichment**  
  After creating a crop season, the response now includes:
  - Full `farmerName`
  - Full `registrationCode`
  - Full `commitmentName`

These improvements ensure that the frontend receives all necessary information immediately after creating a crop season.
