### PR TITLE
refactor(api): rename CropSeasonController to CropSeasonsController a…

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropSeasonsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropSeasonsController.cs
@@ -98,7 +98,6 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             if (result.Status == Const.FAIL_UPDATE_CODE) return Conflict(result.Message);
             return NotFound(result.Message);
         }
-
         [HttpDelete("{cropSeasonId}")]
         public async Task<IActionResult> DeleteCropSeason(Guid cropSeasonId)
         {
@@ -106,10 +105,17 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             try { userId = User.GetUserId(); }
             catch { return Unauthorized("Không xác định được userId từ token."); }
 
-            var result = await _cropSeasonService.DeleteById(cropSeasonId, userId, false);
-            if (result.Status == Const.SUCCESS_DELETE_CODE) return Ok(result.Message);
-            return NotFound(result.Message);
+            var role = User.FindFirst(ClaimTypes.Role)?.Value;
+            bool isAdmin = role == "Admin";
+
+            var result = await _cropSeasonService.DeleteById(cropSeasonId, userId, isAdmin);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok(result.Message);
+
+            return BadRequest(result.Message); // ❗ Dùng BadRequest thay vì NotFound nếu là lỗi quyền
         }
+
 
         [HttpPatch("soft-delete/{cropSeasonId}")]
         public async Task<IActionResult> SoftDeleteCropSeason(Guid cropSeasonId)
@@ -118,9 +124,15 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             try { userId = User.GetUserId(); }
             catch { return Unauthorized("Không xác định được userId từ token."); }
 
-            var result = await _cropSeasonService.SoftDeleteAsync(cropSeasonId, userId, false);
-            if (result.Status == Const.SUCCESS_DELETE_CODE) return Ok(result.Message);
-            return NotFound(result.Message);
+            var role = User.FindFirst(ClaimTypes.Role)?.Value;
+            bool isAdmin = role == "Admin";
+
+            var result = await _cropSeasonService.SoftDeleteAsync(cropSeasonId, userId, isAdmin);
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok(result.Message);
+
+            return BadRequest(result.Message); // Dùng BadRequest thay vì NotFound
         }
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropSeasonDetailRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropSeasonDetailRepository.cs
@@ -2,6 +2,7 @@
 using DakLakCoffeeSupplyChain.Repositories.Models;
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
@@ -10,5 +11,6 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
     {
         Task<List<CropSeasonDetail>> GetByCropSeasonIdAsync(Guid cropSeasonId);
         Task<CropSeasonDetail?> GetByIdAsync(Guid detailId);
+        Task<bool> ExistsAsync(Expression<Func<CropSeasonDetail, bool>> predicate);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropSeasonRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropSeasonRepository.cs
@@ -14,12 +14,12 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
         Task<int> CountByYearAsync(int year);
 
         Task<CropSeason?> GetWithDetailsByIdAsync(Guid cropSeasonId);
+        Task<CropSeason?> GetByIdAsync(Guid cropSeasonId);
 
         Task DeleteCropSeasonDetailsBySeasonIdAsync(Guid cropSeasonId);
 
         Task<bool> ExistsAsync(Expression<Func<CropSeason, bool>> predicate);
         IQueryable<CropSeason> GetQuery();
-
-
+        
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonDetailRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonDetailRepository.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 namespace DakLakCoffeeSupplyChain.Repositories.Repositories
@@ -33,5 +34,10 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
                 .Include(d => d.CoffeeType)
                 .FirstOrDefaultAsync(d => d.DetailId == detailId && !d.IsDeleted);
         }
+        public async Task<bool> ExistsAsync(Expression<Func<CropSeasonDetail, bool>> predicate)
+        {
+            return await _context.CropSeasonDetails.AnyAsync(predicate);
+        }
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropSeasonRepository.cs
@@ -8,19 +8,18 @@ using System.Linq.Expressions;
 public class CropSeasonRepository : GenericRepository<CropSeason>, ICropSeasonRepository
 {
     public CropSeasonRepository(DakLakCoffee_SCMContext context)
-            => _context = context;
+        => _context = context;
 
     public async Task<List<CropSeason>> GetAllCropSeasonsAsync()
     {
         return await _context.CropSeasons
             .AsNoTracking()
-            .Where(c => !c.IsDeleted) 
+            .Where(c => !c.IsDeleted)
             .Include(c => c.Farmer)
                 .ThenInclude(f => f.User)
             .OrderBy(c => c.StartDate)
             .ToListAsync();
     }
-
 
     public async Task<CropSeason?> GetCropSeasonByIdAsync(Guid cropSeasonId)
     {
@@ -47,6 +46,7 @@ public class CropSeasonRepository : GenericRepository<CropSeason>, ICropSeasonRe
         return await _context.CropSeasons
             .CountAsync(c => c.StartDate.HasValue && c.StartDate.Value.Year == year);
     }
+
     public async Task<CropSeason?> GetWithDetailsByIdAsync(Guid cropSeasonId)
     {
         return await _context.CropSeasons
@@ -54,12 +54,17 @@ public class CropSeasonRepository : GenericRepository<CropSeason>, ICropSeasonRe
                 .ThenInclude(d => d.CoffeeType)
             .Include(cs => cs.Farmer)
                 .ThenInclude(f => f.User)
-            .Include(cs => cs.Commitment)           
-            .Include(cs => cs.Registration)       
+            .Include(cs => cs.Commitment)
+            .Include(cs => cs.Registration)
             .FirstOrDefaultAsync(cs => cs.CropSeasonId == cropSeasonId && !cs.IsDeleted);
     }
 
-
+    public async Task<CropSeason?> GetByIdAsync(Guid cropSeasonId)
+    {
+        return await _context.CropSeasons
+            .Include(c => c.Farmer)
+            .FirstOrDefaultAsync(c => c.CropSeasonId == cropSeasonId && !c.IsDeleted);
+    }
 
 
     public async Task DeleteCropSeasonDetailsBySeasonIdAsync(Guid cropSeasonId)
@@ -70,13 +75,14 @@ public class CropSeasonRepository : GenericRepository<CropSeason>, ICropSeasonRe
 
         _context.CropSeasonDetails.RemoveRange(details);
     }
+
     public async Task<bool> ExistsAsync(Expression<Func<CropSeason, bool>> predicate)
     {
         return await _context.CropSeasons.AnyAsync(predicate);
     }
+
     public IQueryable<CropSeason> GetQuery()
     {
         return _context.CropSeasons.AsQueryable();
     }
-
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropSeasonService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropSeasonService.cs
@@ -195,8 +195,17 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             if (cropSeason == null)
                 return new ServiceResult(Const.WARNING_NO_DATA_CODE, Const.WARNING_NO_DATA_MSG);
 
+            // 🔒 Quyền hạn
             if (!isAdmin && cropSeason.Farmer?.UserId != userId)
                 return new ServiceResult(Const.FAIL_DELETE_CODE, "Bạn không có quyền xoá mùa vụ này.");
+
+            // ❗ Chỉ xoá khi status là Cancelled
+            if (cropSeason.Status != "Cancelled")
+                return new ServiceResult(Const.FAIL_DELETE_CODE, "Chỉ có thể xoá mùa vụ đã huỷ.");
+
+            // Nếu có vùng trồng thì không được xoá
+            if (cropSeason.CropSeasonDetails != null && cropSeason.CropSeasonDetails.Any())
+                return new ServiceResult(Const.FAIL_DELETE_CODE, "Không thể xoá mùa vụ đã có vùng trồng.");
 
             await _unitOfWork.CropSeasonRepository.DeleteCropSeasonDetailsBySeasonIdAsync(cropSeasonId);
             _unitOfWork.CropSeasonRepository.PrepareRemove(cropSeason);
@@ -217,6 +226,17 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             if (!isAdmin && cropSeason.Farmer?.UserId != userId)
                 return new ServiceResult(Const.FAIL_DELETE_CODE, "Bạn không có quyền xoá mùa vụ này.");
 
+            // ❗ Chỉ cho xoá mềm nếu status là Cancelled
+            if (cropSeason.Status != "Cancelled")
+                return new ServiceResult(Const.FAIL_DELETE_CODE, "Chỉ có thể xoá mùa vụ đã huỷ.");
+
+            // Kiểm tra có vùng trồng chưa
+            var hasDetails = await _unitOfWork.CropSeasonDetailRepository
+                .ExistsAsync(d => d.CropSeasonId == cropSeasonId && !d.IsDeleted);
+
+            if (hasDetails)
+                return new ServiceResult(Const.FAIL_DELETE_CODE, "Không thể xoá mùa vụ đã có vùng trồng.");
+
             cropSeason.IsDeleted = true;
             cropSeason.UpdatedAt = DateHelper.NowVietnamTime();
 
@@ -227,5 +247,6 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 ? new ServiceResult(Const.SUCCESS_DELETE_CODE, "Xoá mềm mùa vụ thành công.")
                 : new ServiceResult(Const.FAIL_DELETE_CODE, "Xoá mềm mùa vụ thất bại.");
         }
+
     }
 }


### PR DESCRIPTION
- Renamed `CropSeasonController` to `CropSeasonsController` to follow naming conventions.
- Updated controller route handling for crop season APIs.
- Adjusted repository interfaces (`ICropSeasonRepository`, `ICropSeasonDetailRepository`) for better consistency.
- Refactored implementations in `CropSeasonRepository` and `CropSeasonDetailRepository` accordingly.
- Modified `CropSeasonService` to align with new controller structure and logic.
