### PR TITLE
refactor(user-account): enforce role-based access in GetAll API for Admin and BusinessManager

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/UserAccountsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/UserAccountsController.cs
@@ -1,5 +1,6 @@
 ﻿using DakLakCoffeeSupplyChain.Common;
 using DakLakCoffeeSupplyChain.Common.DTOs.UserAccountDTOs;
+using DakLakCoffeeSupplyChain.Common.Helpers;
 using DakLakCoffeeSupplyChain.Services.IServices;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -23,7 +24,21 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [Authorize(Roles = "Admin,BusinessManager")]
         public async Task<IActionResult> GetAllUserAccountsAsync()
         {
-            var result = await _userAccountService.GetAll();
+            Guid userId;
+            string userRole;
+
+            try
+            {
+                // Lấy userId và userRole từ token qua ClaimsHelper
+                userId = User.GetUserId();
+                userRole = User.GetRole();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId hoặc role từ token.");
+            }
+
+            var result = await _userAccountService.GetAll(userId, userRole);
 
             if (result.Status == Const.SUCCESS_READ_CODE)
                 return Ok(result.Data);         

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IUserAccountService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IUserAccountService.cs
@@ -10,7 +10,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 {
     public interface IUserAccountService
     {
-        Task<IServiceResult> GetAll();
+        Task<IServiceResult> GetAll(Guid userId, string userRole);
 
         Task<IServiceResult> GetById(Guid userId);
 


### PR DESCRIPTION
## ☕ Feature: UserAccount – GetAll API (Admin & BusinessManager)

### 📌 Objective
Refactor the `GetAll` API in `UserAccountService` to enforce **role-based access control**, allowing:
- `Admin` to retrieve all users.
- `BusinessManager` to retrieve only staff under their supervision.

---

### ✅ Key Changes
- Refactored `GetAll` method in `UserAccountService` to conditionally filter by role.
- Integrated `SupervisorId` check for `BusinessManager` access logic.
- Injected `userId` and `userRole` from claims in `UserAccountsController`.
- Improved clarity and separation of responsibilities between Admin and Manager access paths.
- Added safeguard at service level to prevent misuse from external calls.

---

### 🧱 Affected Files
- `UserAccountsController.cs`
- `UserAccountService.cs`
- `IUserAccountService.cs`

---

### 📁 Added
- _N/A_ (no new files introduced)

---

### 🧪 How to Test
1. **Login** with an `Admin` or `BusinessManager` account to get the JWT token.
2. Send a request to:
   - `GET /api/useraccounts`
   - Header: `Authorization: Bearer {token}`
3. Verify response:
   - Admin should see all users.
   - BusinessManager should see only users they supervise.

---

### 🧪 Test Cases
- [x] ✅ Admin retrieves all users  
- [x] ✅ BusinessManager retrieves only their staff  
- [x] ❌ BusinessManager cannot access users outside their scope  
- [x] ❌ Unauthorized roles are blocked with proper error message

---

### 🔍 Notes
- Role check logic duplicated at both controller (via `[Authorize]`) and service (for extra protection).
- Mapping relies on `MapToUserAccountViewAllDto()`.
- 💡 Could consider pagination and search filters for large datasets in future.

---

### 🔗 Related
- Modules: `UserAccount`, `BusinessManager`, `BusinessStaff`
- Roles: `Admin`, `BusinessManager`
