### PR TITLE
refactor(order): enforce role-based access in GetById API for BusinessManager and Staff

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/OrdersController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/OrdersController.cs
@@ -53,7 +53,19 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [Authorize(Roles = "BusinessManager,BusinessStaff")]
         public async Task<IActionResult> GetById(Guid orderId)
         {
-            var result = await _orderService.GetById(orderId);
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
+            var result = await _orderService.GetById(orderId, userId);
 
             if (result.Status == Const.SUCCESS_READ_CODE)
                 return Ok(result.Data);              // Trả object chi tiết
@@ -85,7 +97,19 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
         private async Task<bool> OrderExistsAsync(Guid orderId)
         {
-            var result = await _orderService.GetById(orderId);
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return false;
+            }
+
+            var result = await _orderService.GetById(orderId, userId);
 
             return result.Status == Const.SUCCESS_READ_CODE;
         }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IOrderService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IOrderService.cs
@@ -11,7 +11,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
     {
         Task<IServiceResult> GetAll(Guid userId);
 
-        Task<IServiceResult> GetById(Guid orderId);
+        Task<IServiceResult> GetById(Guid orderId, Guid userId);
 
         Task<IServiceResult> SoftDeleteOrderById(Guid orderId);
     }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/OrderService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/OrderService.cs
@@ -79,7 +79,8 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             );
 
             // Kiểm tra nếu không có dữ liệu
-            if (orders == null || !orders.Any())
+            if (orders == null || 
+                !orders.Any())
             {
                 return new ServiceResult(
                     Const.WARNING_NO_DATA_CODE,
@@ -102,13 +103,54 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             }
         }
 
-        public async Task<IServiceResult> GetById(Guid orderId)
+        public async Task<IServiceResult> GetById(Guid orderId, Guid userId)
         {
+            Guid? managerId = null;
+
+            // Ưu tiên kiểm tra BusinessManager
+            var manager = await _unitOfWork.BusinessManagerRepository.GetByIdAsync(
+                predicate: m => 
+                   m.UserId == userId && 
+                   !m.IsDeleted,
+                asNoTracking: true
+            );
+
+            if (manager != null)
+            {
+                managerId = manager.ManagerId;
+            }
+            else
+            {
+                // Nếu không phải Manager, kiểm tra BusinessStaff
+                var staff = await _unitOfWork.BusinessStaffRepository.GetByIdAsync(
+                    predicate: s => 
+                       s.UserId == userId && 
+                       !s.IsDeleted,
+                    asNoTracking: true
+                );
+
+                if (staff != null)
+                {
+                    managerId = staff.SupervisorId;
+                }
+            }
+
+            if (managerId == null)
+            {
+                return new ServiceResult(
+                    Const.WARNING_NO_DATA_CODE,
+                    "Không tìm thấy Manager hoặc Staff tương ứng với tài khoản."
+                );
+            }
+
             // Tìm order theo ID
             var order = await _unitOfWork.OrderRepository.GetByIdAsync(
                 predicate: o =>
                    o.OrderId == orderId &&
-                   !o.IsDeleted,
+                   !o.IsDeleted &&
+                   o.DeliveryBatch != null &&
+                   o.DeliveryBatch.Contract != null &&
+                   o.DeliveryBatch.Contract.SellerId == managerId,
                 include: query => query
                    .Include(o => o.DeliveryBatch)
                       .ThenInclude(db => db.Contract)


### PR DESCRIPTION
## ☕ Feature: Order – GetById API with Role-Based Access

### 📌 Objective
Enhance the `GetById` API for Orders to enforce role-based access control. Ensures that only the owning `BusinessManager` or their assigned `BusinessStaff` can view the details of an order that belongs to them.

---

### ✅ Key Changes
- Refactored `GetById(Guid orderId)` to `GetById(Guid orderId, Guid userId)` in `OrderService`
- Added logic to resolve `managerId` from `userId` for both `BusinessManager` and `BusinessStaff`
- Updated predicate to restrict access to orders belonging to the current manager
- Adjusted `OrdersController` to extract `userId` from token via `ClaimsHelper`
- Synchronized logic with `GetAll` for consistency in access control

---

### 🧱 Affected Files
- `OrdersController.cs`
- `OrderService.cs`
- `IOrderService.cs`

---

### 📁 Added
- _N/A_

---

### 🧪 How to Test
1. **Login** as `BusinessManager` or `BusinessStaff`
2. Send request to endpoint:
   - `GET /api/orders/{orderId}`
   - Header: `Authorization: Bearer {token}`
3. Verify:
   - You only receive data if the order belongs to your manager scope
   - If the order does not belong to you, response is `404 Not Found`

---

### 🧪 Test Cases
- [x] ✅ Valid order owned by manager → returns `200 OK` with full detail  
- [x] ❌ Order not belonging to current user → returns `404 Not Found`  
- [x] ❌ Deleted order → returns `404 Not Found`  
- [x] ❌ No token or invalid token → returns `401 Unauthorized`  

---

### 🔍 Notes
- Ensures no cross-access between managers or unrelated staff
- Protects against ID guessing attack on `GetById` endpoint
- Shared logic for `managerId` resolution reused from `GetAll`
- 💡 Suggest refactoring `ResolveManagerId(userId)` into a helper or base service for reuse

---

### 🔗 Related
- Modules: `Order`, `BusinessManager`, `BusinessStaff`
- Roles: `BusinessManager`, `BusinessStaff`
