### PR TITLE
feat(warehouse): fix name duplication check when updating

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/WarehousesController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/WarehousesController.cs
@@ -78,7 +78,7 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
         // PUT: api/Warehouses/{id}
         [HttpPut("{id}")]
-        [Authorize(Roles = "Admin")]
+        [Authorize(Roles = "Admin, BusinessManager")]
         public async Task<IActionResult> Update(Guid id, [FromBody] WarehouseUpdateDto dto)
         {
             var result = await _warehouseService.UpdateAsync(id, dto);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IWarehouseRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IWarehouseRepository.cs
@@ -11,7 +11,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
 {
     public interface IWarehouseRepository : IGenericRepository<Warehouse>
     {
-        Task<bool> IsNameExistsAsync(string name);
+        Task<bool> IsNameExistsAsync(string name, Guid? excludeId = null);
         Task<IEnumerable<Warehouse>> FindAsync(Expression<Func<Warehouse, bool>> predicate);
         Task<Warehouse?> GetByIdAsync(Guid id);
         void Update(Warehouse entity);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/WarehouseRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/WarehouseRepository.cs
@@ -16,9 +16,12 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
     {
         public WarehouseRepository(DakLakCoffee_SCMContext context) : base(context) { }
 
-        public async Task<bool> IsNameExistsAsync(string name)
+        public async Task<bool> IsNameExistsAsync(string name, Guid? excludeId = null)
         {
-            return await _context.Warehouses.AnyAsync(w => w.Name == name && !w.IsDeleted);
+            return await _context.Warehouses.AnyAsync(w =>
+                w.Name == name &&
+                !w.IsDeleted &&
+                (excludeId == null || w.WarehouseId != excludeId));
         }
         public async Task<IEnumerable<Warehouse>> FindAsync(Expression<Func<Warehouse, bool>> predicate)
         {

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/WarehouseService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/WarehouseService.cs
@@ -101,7 +101,8 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             if (warehouse == null)
                 return new ServiceResult(Const.FAIL_READ_CODE, "Không tìm thấy kho.");
 
-            if (await _unitOfWork.Warehouses.IsNameExistsAsync(dto.Name))
+            // Loại trừ chính bản ghi hiện tại khỏi kiểm tra trùng tên
+            if (await _unitOfWork.Warehouses.IsNameExistsAsync(dto.Name, warehouse.WarehouseId))
                 return new ServiceResult(Const.FAIL_UPDATE_CODE, "Tên kho đã tồn tại.");
 
             dto.MapToEntity(warehouse);
@@ -111,7 +112,6 @@ namespace DakLakCoffeeSupplyChain.Services.Services
 
             return new ServiceResult(Const.SUCCESS_UPDATE_CODE, "Cập nhật kho thành công.");
         }
-
         public async Task<IServiceResult> DeleteAsync(Guid warehouseId)
         {
             var warehouse = await _unitOfWork.Warehouses.GetDeletableByIdAsync(warehouseId);


### PR DESCRIPTION
☕ Feature: Warehouse – Update API enhancement
📌 Objective
Improve the update logic of the Warehouse API to prevent false-positive name duplication errors when updating an existing warehouse. This affects the BusinessManager role's ability to edit warehouse details.

✅ Key Changes
✅ Adjusted the name duplication check in WarehouseService.UpdateAsync() to exclude the current warehouse record from the query.

✅ Updated IWarehouseRepository and WarehouseRepository with a new method: IsNameExistsExceptAsync(string name, Guid exceptId)

✅ Ensured only actual duplicates trigger conflict response, allowing location/capacity changes without renaming.

🧱 Affected Files
WarehouseService.cs

IWarehouseRepository.cs

WarehouseRepository.cs

📁 Added
IsNameExistsExceptAsync method in WarehouseRepository.cs

🧪 How to Test
Login as a BusinessManager to get JWT token

Send PUT request to:

PUT /api/Warehouses/{warehouseId}

Header: Authorization: Bearer {token}

Sample request body:

json
Sao chép
Chỉnh sửa
{
  "warehouseId": "abc-def-123",
  "name": "Kho Chợ Hạnh Thông Tây",
  "location": "Tân Bình",
  "capacity": 10000000,
  "managerId": "ghi-jkl-456"
}
🧪 Test Cases
 ✅ Update warehouse location/capacity only with same name → Success

 ❌ Update warehouse with duplicate name from another warehouse → Rejected

 ✅ Update all fields with a unique name → Success

🔍 Notes
Logic ensures that name check excludes the current warehouse being updated.

Prevents 409 Conflict when updating only non-name fields.

No DB constraint change required.

🔗 Related
Modules: Warehouse, BusinessManager

Roles: BusinessManager

