### PR TITLE
refactor(user-account): enforce role-based access in Update API with claims check and CanAccessUser validation

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/UserAccountsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/UserAccountsController.cs
@@ -132,6 +132,26 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
+            Guid currentUserId;
+            string currentUserRole;
+
+            try
+            {
+                // Lấy userId và userRole từ token qua ClaimsHelper
+                currentUserId = User.GetUserId();
+                currentUserRole = User.GetRole();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId hoặc role từ token.");
+            }
+
+            // Kiểm tra quyền cập nhật userId
+            var canAccess = await _userAccountService.CanAccessUser(currentUserId, currentUserRole, userId);
+
+            if (!canAccess)
+                return StatusCode(403, "Bạn không có quyền cập nhật thông tin người dùng này.");
+
             var result = await _userAccountService.Update(userDto);
 
             if (result.Status == Const.SUCCESS_UPDATE_CODE)


### PR DESCRIPTION
## ☕ Feature: Update UserAccount API with role-based access

### 📌 Objective
Enhance the existing `UpdateUserAccount` API to include strict role-based access control.  
Ensure only authorized users (e.g., Admin, BusinessManager, or self) can update a given user, based on claims from JWT token.

---

### ✅ Key Changes
- Implemented `UpdateUserAccountAsync` in `UserAccountsController` with `GetUserId()` and `GetRole()` from claims
- Added permission check via `_userAccountService.CanAccessUser(...)`
- Improved HTTP response handling with proper 403, 404, 409, and 500 statuses

---

### 🧱 Affected Files
- `UserAccountsController.cs`

---

### 📁 Added
- N/A

---

### 🧪 How to Test
1. **Login** using a valid user with different roles (e.g., `Admin`, `BusinessManager`, `Farmer`)
2. Send request to endpoint:
   - `PUT /api/useraccounts/{userId}`
   - Header: `Authorization: Bearer {token}`
3. Sample request body:
```json
{
  "UserId": "d15d2df0-a6fa-4f09-bb42-12fbd78e4f1a",
  "Email": "test@example.com",
  "PhoneNumber": "0912345678",
  "Name": "Updated User",
  "Gender": "Male",
  "DateOfBirth": "2001-10-12",
  "Address": "123 New Street",
  "ProfilePictureUrl": null,
  "Status": "Active",
  "RoleName": "Farmer"
}
```

---

### 🧪 Test Cases
- [x] ✅ Update own account as `Farmer` → success  
- [x] ✅ Update staff as `BusinessManager` → success if `SupervisorId` matches  
- [x] ❌ Attempt to update other users without permission → return `403 Forbidden`  
- [x] ✅ Update as `Admin` → always allowed  
- [x] ❌ Mismatched `userId` in route and body → return `400 BadRequest`  
- [x] ❌ Invalid email or phone duplication → return `409 Conflict`  

---

### 🔍 Notes
- Uses `ClaimsPrincipal` extension methods for consistent user identification  
- Age is validated using `MIN_AGE_FOR_REGISTRATION` config (default: `18`)  
- Requires `RoleName` mapping to `RoleId` before update  
- Return object is mapped via `MapToUserAccountViewDetailsDto`

---

### 🔗 Related
- **Modules**: `UserAccount`, `Role`, `BusinessStaff`, `BusinessManager`  
- **Roles**: `Admin`, `BusinessManager`, `Farmer`, `DeliveryStaff`, `Expert`, `BusinessStaff`
