### PR TITLE
refactor(user-account): add permission check in SoftDelete API using CanAccessUser for role-safe deletion

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/UserAccountsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/UserAccountsController.cs
@@ -190,6 +190,26 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [Authorize(Roles = "Admin,BusinessManager,AgriculturalExpert,Farmer")]
         public async Task<IActionResult> SoftDeleteUserAccountByIdAsync(Guid userId)
         {
+            Guid currentUserId;
+            string currentUserRole;
+
+            try
+            {
+                // Lấy userId và userRole từ token qua ClaimsHelper
+                currentUserId = User.GetUserId();
+                currentUserRole = User.GetRole();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId hoặc role từ token.");
+            }
+
+            // Kiểm tra quyền xóa mềm userId
+            var canAccess = await _userAccountService.CanAccessUser(currentUserId, currentUserRole, userId);
+
+            if (!canAccess)
+                return StatusCode(403, "Bạn không có quyền xóa người dùng này.");
+
             var result = await _userAccountService.SoftDeleteById(userId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)


### PR DESCRIPTION
## ☕ Feature: SoftDelete UserAccount API – Add permission check

### 📌 Objective
Introduce role-based permission validation into the `SoftDeleteUserAccountByIdAsync` API to prevent unauthorized users from soft-deleting accounts.  
Ensure users can only soft-delete their own account or accounts they are authorized to manage (e.g., Admin or BusinessManager).

---

### ✅ Key Changes
- Added `GetUserId()` and `GetRole()` extraction from JWT token using `ClaimsHelper`
- Integrated `_userAccountService.CanAccessUser(...)` to verify soft-delete permission
- Returned appropriate HTTP status codes (401, 403, 404, 409, 500)

---

### 🧱 Affected Files
- `UserAccountsController.cs`

---

### 📁 Added
- N/A

---

### 🧪 How to Test
1. **Login** using a valid user role (`Admin`, `BusinessManager`, `Farmer`, `AgriculturalExpert`) to get JWT token
2. Send PATCH request to:
   - `PATCH /api/useraccounts/soft-delete/{userId}`
   - Header: `Authorization: Bearer {token}`
3. No body is required for this endpoint

---

### 🧪 Test Cases
- [x] ✅ Soft-delete own account as `Farmer` → success  
- [x] ✅ Soft-delete staff account as `BusinessManager` (with valid supervisor relation) → success  
- [x] ❌ Attempt to delete unrelated account → return 403  
- [x] ✅ Admin soft-deleting any account → success  
- [x] ❌ Invalid userId (not found) → return 404  

---

### 🔍 Notes
- Shares permission logic with `Update` and `GetById` APIs via `CanAccessUser`
- Helps enforce consistent access control across APIs
- Ensures security for self-service roles like `Farmer`, `AgriculturalExpert`

---

### 🔗 Related
- Modules: `UserAccount`, `Role`, `BusinessStaff`, `BusinessManager`  
- Roles: `Admin`, `BusinessManager`, `Farmer`, `AgriculturalExpert`
