### PR TITLE
refactor(user-account): enforce scoped deletion permission for BusinessManager in Delete API

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
 ## ☕ Feature: [Tên tính năng/API ngắn gọn]
-<!-- VD: Admin – Quản lý người dùng (UI) -->
 
 ### 📌 Objective
 [Mô tả mục tiêu của PR: bạn đang thêm, sửa, hoặc cải tiến điều gì? Liên quan đến vai trò hoặc luồng nào?]

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/UserAccountsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/UserAccountsController.cs
@@ -147,7 +147,8 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             }
 
             // Kiểm tra quyền cập nhật userId
-            var canAccess = await _userAccountService.CanAccessUser(currentUserId, currentUserRole, userId);
+            var canAccess = await _userAccountService
+                .CanAccessUser(currentUserId, currentUserRole, userId);
 
             if (!canAccess)
                 return StatusCode(403, "Bạn không có quyền cập nhật thông tin người dùng này.");
@@ -171,7 +172,21 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [Authorize(Roles = "Admin,BusinessManager")]
         public async Task<IActionResult> DeleteUserAccountByIdAsync(Guid userId)
         {
-            var result = await _userAccountService.DeleteById(userId);
+            Guid currentUserId;
+            string currentUserRole;
+
+            try
+            {
+                // Lấy userId và userRole từ token qua ClaimsHelper
+                currentUserId = User.GetUserId();
+                currentUserRole = User.GetRole();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId hoặc role từ token.");
+            }
+
+            var result = await _userAccountService.DeleteById(userId, currentUserId, currentUserRole);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok("Xóa thành công.");
@@ -205,7 +220,8 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             }
 
             // Kiểm tra quyền xóa mềm userId
-            var canAccess = await _userAccountService.CanAccessUser(currentUserId, currentUserRole, userId);
+            var canAccess = await _userAccountService
+                .CanAccessUser(currentUserId, currentUserRole, userId);
 
             if (!canAccess)
                 return StatusCode(403, "Bạn không có quyền xóa người dùng này.");

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IUserAccountService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IUserAccountService.cs
@@ -18,7 +18,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Update(UserAccountUpdateDto userDto);
 
-        Task<IServiceResult> DeleteById(Guid userId);
+        Task<IServiceResult> DeleteById(Guid userId, Guid currentUserId, string currentUserRole);
 
         Task<IServiceResult> SoftDeleteById(Guid userId);
 


### PR DESCRIPTION
## ☕ Feature: Delete UserAccount API with scoped access control

### 📌 Objective
Refactor the `DeleteUserAccountByIdAsync` API to enforce role-based deletion rules.  
Ensure only `Admin` or `BusinessManager` users can delete a user, and restrict `BusinessManager` to delete only `BusinessStaff` under their supervision.

---

### ✅ Key Changes
- Extracted `currentUserId` and `currentUserRole` from JWT token using `ClaimsHelper`
- Added role validation and supervisory check logic in `DeleteById` service method
- Handled response codes for unauthorized access, invalid targets, and operation failures

---

### 🧱 Affected Files
- `UserAccountsController.cs`
- `UserAccountService.cs`
- `IUserAccountService.cs`

---

### 📁 Added
- N/A

---

### 🧪 How to Test
1. **Login** with one of the allowed roles: `Admin`, `BusinessManager`
2. Send request to the endpoint:
   - `DELETE /api/useraccounts/{userId}`
   - Header: `Authorization: Bearer {token}`
3. No request body is required

---

### 🧪 Test Cases
- [x] ✅ Delete any user as `Admin` → success  
- [x] ✅ Delete `BusinessStaff` under self as `BusinessManager` → success  
- [x] ❌ Delete unrelated user as `BusinessManager` → return 409 (permission denied)  
- [x] ❌ Delete user with invalid ID → return 404  
- [x] ❌ Role not authorized (e.g., `Farmer`) → return 403  

---

### 🔍 Notes
- Validates supervisory relationship via `SupervisorId` and `ManagerId`
- Uses `UserAccountRepository` with `Include(u => u.Role)` to support later logic
- Reuses consistent response codes and message patterns from other APIs

---

### 🔗 Related
- Modules: `UserAccount`, `Role`, `BusinessStaff`, `BusinessManager`  
- Roles: `Admin`, `BusinessManager`
