### PR TITLE
feat(api): support crop season update with commitmentId validation

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropSeasonsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropSeasonsController.cs
@@ -128,6 +128,7 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             return NotFound(result.Message);
         }
 
+
         // ✅ Chỉ Admin hoặc người tạo được xoá
         [HttpDelete("{cropSeasonId}")]
         [Authorize(Roles = "Admin,BusinessManager,Farmer")]

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonUpdateDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/CropSeasonDTOs/CropSeasonUpdateDto.cs
@@ -12,8 +12,8 @@ namespace DakLakCoffeeSupplyChain.Common.DTOs.CropSeasonDTOs
         //[Required]
         //public Guid FarmerId { get; set; }
 
-        [Required]
-        public Guid RegistrationId { get; set; }
+        //[Required]
+        //public Guid RegistrationId { get; set; }
 
         [Required]
         public Guid CommitmentId { get; set; }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/CropSeasonMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/CropSeasonMapper.cs
@@ -95,7 +95,6 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
         public static void MapToExistingEntity(this CropSeasonUpdateDto dto, CropSeason entity)
         {
             entity.SeasonName = dto.SeasonName;
-            entity.RegistrationId = dto.RegistrationId;
             entity.CommitmentId = dto.CommitmentId;
             entity.Area = dto.Area;
             entity.StartDate = dto.StartDate;

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropSeasonService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropSeasonService.cs
@@ -180,7 +180,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 return new ServiceResult(Const.FAIL_UPDATE_CODE, "Ngày bắt đầu phải trước ngày kết thúc.");
 
             bool isDuplicate = await _unitOfWork.CropSeasonRepository.ExistsAsync(
-                x => x.RegistrationId == dto.RegistrationId &&
+                     x => x.RegistrationId == cropSeason.RegistrationId &&  // ✅ dùng từ DB
                      x.StartDate.HasValue &&
                      x.StartDate.Value.Year == dto.StartDate.Year &&
                      x.CropSeasonId != dto.CropSeasonId


### PR DESCRIPTION
feat(api): support crop season update with commitmentId validation

- Cho phép cập nhật thông tin mùa vụ bao gồm: seasonName, commitmentId, area, startDate, endDate, note, status
- Validate: không cho phép startDate >= endDate
- Validate: không cho phép duplicate mùa vụ cùng RegistrationId trong cùng năm (ngoại trừ chính nó)
- Phân quyền: chỉ cho phép Admin hoặc chủ sở hữu (Farmer) thực hiện cập nhật
- Cập nhật phương thức MapToExistingEntity để đồng bộ với DTO mới
- Thêm kiểm tra cropSeasonId khớp với route trong controller
