### PR TITLE
feat: implement update API for ProcessingBatch with ownership and val…

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingBatchsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingBatchsController.cs
@@ -71,5 +71,26 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             return BadRequest(result.Message);
         }
+        [HttpPut]
+        [Authorize(Roles = "Farmer")]
+        public async Task<IActionResult> Update([FromBody] ProcessingBatchUpdateDto dto)
+        {
+            var userIdStr = User.FindFirst("userId")?.Value
+                         ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            if (!Guid.TryParse(userIdStr, out var userId))
+                return BadRequest("Không thể lấy userId từ token.");
+
+            var result = await _processingbatchservice.UpdateAsync(dto, userId);
+
+            if (result.Status == Const.SUCCESS_UPDATE_CODE)
+                return Ok(result.Data);
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound(result.Message);
+
+            return BadRequest(result.Message);
+        }
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcessingBatchDTOs/ProcessingBatchUpdateDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcessingBatchDTOs/ProcessingBatchUpdateDto.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.ProcessingBatchDTOs
+{
+    public class ProcessingBatchUpdateDto
+    {
+        public Guid BatchId { get; set; }
+        public string BatchCode { get; set; }
+        public Guid CoffeeTypeId { get; set; }
+        public Guid CropSeasonId { get; set; }
+        public int MethodId { get; set; }
+        public double InputQuantity { get; set; }
+        public string InputUnit { get; set; }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingBatchService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingBatchService.cs
@@ -13,5 +13,6 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> GetAll();
         Task<IServiceResult> GetAllByUserId(Guid userId, bool isAdmin = false);
         Task<IServiceResult> CreateAsync(ProcessingBatchCreateDto dto, Guid userId);
+        Task<IServiceResult> UpdateAsync(ProcessingBatchUpdateDto dto, Guid userId);
     }
 }


### PR DESCRIPTION
## ☕ Feature: Update API for ProcessingBatch

### 📌 Objective  
Allow `Farmer` users to update their own `ProcessingBatch` records with full validation and authorization.

---

### ✅ Key Changes
- Added `UpdateAsync` method in `ProcessingBatchService`
- Checked ownership: only the owning `Farmer` can update their batch
- Validated foreign keys: `CoffeeType`, `CropSeason`, `Method`
- Trimmed input, handled nulls, updated `UpdatedAt` timestamp
- Mapped back updated entity to `ProcessingBatchViewDto` for response
- Registered `PUT /api/ProcessingBatch` endpoint with `[Authorize(Roles = "Farmer")]`

---

### 🧱 Affected Files
- `ProcessingBatchService.cs`
- `IProcessingBatchService.cs`
- `ProcessingBatchController.cs`
- `ProcessingBatchUpdateDto.cs`

---

### 🧪 How to Test
1. **Login** as a `Farmer` and get JWT token
2. Send `PUT` request to:
   - `/api/ProcessingBatch`
   - Header: `Authorization: Bearer {token}`
3. Sample body:
```json
{
  "batchId": "b4ec1b9d-7e11-4de6-8c2b-bc2e6d5bce5d",
  "batchCode": "Lô cập nhật API",
  "coffeeTypeId": "6efa7bc2-b9b9-49c9-9941-10de40c390aa",
  "cropSeasonId": "8ceb6d15-bd57-4d19-b7f2-0cf6c93140b6",
  "methodId": 1,
  "inputQuantity": 1200,
  "inputUnit": "kg"
}
