### PR TITLE
feat: implement soft delete API for ProcessingBatch with farmer owner…

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingBatchsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingBatchsController.cs
@@ -91,6 +91,25 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             return BadRequest(result.Message);
         }
+        [HttpDelete("{id}")]
+        [Authorize(Roles = "Farmer")]
+        public async Task<IActionResult> SoftDelete(Guid id)
+        {
+            var userIdStr = User.FindFirst("userId")?.Value
+                         ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
 
+            if (!Guid.TryParse(userIdStr, out var userId))
+                return BadRequest("Không thể lấy userId từ token.");
+
+            var result = await _processingbatchservice.SoftDeleteAsync(id, userId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok(result.Message);
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound(result.Message);
+
+            return BadRequest(result.Message);
+        }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingBatchService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingBatchService.cs
@@ -14,5 +14,6 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> GetAllByUserId(Guid userId, bool isAdmin = false);
         Task<IServiceResult> CreateAsync(ProcessingBatchCreateDto dto, Guid userId);
         Task<IServiceResult> UpdateAsync(ProcessingBatchUpdateDto dto, Guid userId);
+        Task<IServiceResult> SoftDeleteAsync(Guid batchId, Guid userId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProcessingBatchService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProcessingBatchService.cs
@@ -232,6 +232,53 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 return new ServiceResult(Const.ERROR_EXCEPTION, ex.Message);
             }
         }
+        public async Task<IServiceResult> SoftDeleteAsync(Guid batchId, Guid userId)
+        {
+            try
+            {
+                // Lấy Farmer theo userId
+                var farmer = await _unitOfWork.FarmerRepository.FindByUserIdAsync(userId);
+                if (farmer == null)
+                {
+                    return new ServiceResult(Const.FAIL_DELETE_CODE, "Chỉ Farmer mới có quyền xóa mẻ sơ chế.");
+                }
+
+                // Tìm mẻ sơ chế cần xóa
+                var batch = await _unitOfWork.ProcessingBatchRepository.GetByIdAsync(
+                    predicate: x => x.BatchId == batchId && !x.IsDeleted,
+                    asNoTracking: false
+                );
+
+                if (batch == null)
+                {
+                    return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Không tìm thấy mẻ sơ chế.");
+                }
+
+                // Chặn xóa nếu không phải của Farmer hiện tại
+                if (batch.FarmerId != farmer.FarmerId)
+                {
+                    return new ServiceResult(Const.FAIL_DELETE_CODE, "Không được xóa mẻ sơ chế của người khác.");
+                }
+
+                batch.IsDeleted = true;
+                batch.UpdatedAt = DateTime.UtcNow;
+
+                _unitOfWork.ProcessingBatchRepository.PrepareUpdate(batch);
+
+                var result = await _unitOfWork.SaveChangesAsync();
+
+                if (result > 0)
+                {
+                    return new ServiceResult(Const.SUCCESS_DELETE_CODE, "Xóa mềm mẻ sơ chế thành công.");
+                }
+
+                return new ServiceResult(Const.FAIL_DELETE_CODE, Const.FAIL_DELETE_MSG);
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult(Const.ERROR_EXCEPTION, ex.Message);
+            }
+        }
 
 
     }


### PR DESCRIPTION
## 🗑️ Feature: Soft Delete for ProcessingBatch

### 📌 Objective  
Allow `Farmer` users to soft-delete (`IsDeleted = true`) their own `ProcessingBatch` records via API.

---

### ✅ Key Changes
- Added `SoftDeleteAsync(Guid batchId, Guid userId)` in `ProcessingBatchService`
- Verified that the `Farmer` owns the batch before allowing deletion
- Updated `IsDeleted = true` and `UpdatedAt` timestamp
- Registered `DELETE /api/ProcessingBatch/{id}` endpoint with `[Authorize(Roles = "Farmer")]`

---

### 🧱 Affected Files
- `ProcessingBatchService.cs`
- `IProcessingBatchService.cs`
- `ProcessingBatchController.cs`

---

### 🧪 How to Test
1. **Login** as a `Farmer` and get a valid token
2. Send `DELETE` request to:
   - `/api/ProcessingBatch/{batchId}`
   - Header: `Authorization: Bearer {token}`
3. Ensure batch is soft-deleted (`IsDeleted = true`) and no longer appears in `GetAll`

---

### ✅ Test Cases
- [x] ✅ Soft delete own batch successfully
- [x] ❌ Cannot delete another farmer’s batch
- [x] ❌ Return 404 if batch not found
- [x] ✅ Confirm soft-deleted batch is excluded from listings

---

### 🔍 Notes
- Requires all `GetAll()` and related queries to filter `IsDeleted == false`
- Can extend later with restore or hard delete if needed
