### PR TITLE
feat: implement hard delete API for ProcessingBatch with farmer owner…

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingBatchsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingBatchsController.cs
@@ -111,5 +111,26 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             return BadRequest(result.Message);
         }
+        [HttpDelete("hard/{id}")]
+        [Authorize(Roles = "Farmer")]
+        public async Task<IActionResult> HardDelete(Guid id)
+        {
+            var userIdStr = User.FindFirst("userId")?.Value
+                         ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            if (!Guid.TryParse(userIdStr, out var userId))
+                return BadRequest("Không thể lấy userId từ token.");
+
+            var result = await _processingbatchservice.HardDeleteAsync(id, userId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok(result.Message);
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound(result.Message);
+
+            return BadRequest(result.Message);
+        }
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingBatchService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingBatchService.cs
@@ -15,5 +15,6 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> CreateAsync(ProcessingBatchCreateDto dto, Guid userId);
         Task<IServiceResult> UpdateAsync(ProcessingBatchUpdateDto dto, Guid userId);
         Task<IServiceResult> SoftDeleteAsync(Guid batchId, Guid userId);
+        Task<IServiceResult> HardDeleteAsync(Guid batchId, Guid userId);
     }
 }


### PR DESCRIPTION
## 🗑️ Feature: Hard Delete for ProcessingBatch

### 📌 Objective  
Allow `Farmer` users to permanently delete their own `ProcessingBatch` from the database. This is useful for data cleanup, testing, or strict removal cases.

---

### ✅ Key Changes
- Added `HardDeleteAsync(Guid batchId, Guid userId)` in `ProcessingBatchService`
- Enforced ownership check: only the batch owner (`Farmer`) can delete it
- Used `RemoveAsync()` to permanently delete from DB
- Registered endpoint `DELETE /api/ProcessingBatch/hard/{id}` restricted to `Farmer` role

---

### 🧱 Affected Files
- `ProcessingBatchService.cs`
- `IProcessingBatchService.cs`
- `ProcessingBatchController.cs`
- `IGenericRepository.cs` (Ensure `RemoveAsync()` exists)

---

### 🧪 How to Test
1. **Login** as a `Farmer` and get JWT token
2. Send `DELETE` request to:
   - `https://localhost:{port}/api/ProcessingBatch/hard/{batchId}`
   - Header: `Authorization: Bearer {token}`
3. Expected result: 200 OK with message `"Đã xóa vĩnh viễn mẻ sơ chế."`

---

### ✅ Test Cases
- [x] ✅ Successfully delete owned batch
- [x] ❌ Prevent deletion of another farmer's batch
- [x] ❌ Return 404 if batch not found
- [x] ✅ Confirm batch is removed from DB (not just marked deleted)

---

### 🔍 Notes
- This action is **irreversible**
- You may want to restrict this API in production or behind confirmation logic
- Soft delete is still the recommended default behavior for most flows
