### PR TITLE
refactor(business-buyer): enforce access control in Delete API to ensure buyer belongs to current BusinessManager

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@
 
 ---
 
-### 🧪 How to Test
+### 🛠️ How to Test
 1. **Login** bằng role phù hợp (VD: `BusinessManager`) để lấy JWT token
 2. Gửi request đến endpoint:
    - `POST /api/businessbuyers` (hoặc endpoint bạn thêm)

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessBuyersController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessBuyersController.cs
@@ -150,7 +150,19 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [HttpDelete("{buyerId}")]
         public async Task<IActionResult> DeleteBusinessBuyerByIdAsync(Guid buyerId)
         {
-            var result = await _businessBuyerService.DeleteBusinessBuyerById(buyerId);
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
+            var result = await _businessBuyerService.DeleteBusinessBuyerById(buyerId, userId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok("Xóa thành công.");

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessBuyerService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessBuyerService.cs
@@ -18,7 +18,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Update(BusinessBuyerUpdateDto businessBuyerDto, Guid userId);
 
-        Task<IServiceResult> DeleteBusinessBuyerById(Guid buyerId);
+        Task<IServiceResult> DeleteBusinessBuyerById(Guid buyerId, Guid userId);
 
         Task<IServiceResult> SoftDeleteBusinessBuyerById(Guid buyerId);
     }


### PR DESCRIPTION
## ☕ Feature: Delete BusinessBuyer API with Role-based Access Control

### 📌 Objective
Implement secure deletion logic for BusinessBuyer records. Ensure only the BusinessManager who created the buyer can delete it, enforcing access control based on JWT claims. This improves data integrity and prevents unauthorized access.

---

### ✅ Key Changes
- Add `userId` parameter to `DeleteBusinessBuyerById` to enforce ownership check
- Validate that only the creator BusinessManager can delete the buyer
- Filter out soft-deleted records in permission logic
- Clean up and unify logic with GetAll / GetById access pattern

---

### 🧱 Affected Files
- `BusinessBuyersController.cs`
- `BusinessBuyerService.cs`
- `IBusinessBuyerService.cs`
- `.github/PULL_REQUEST_TEMPLATE.md`

---

### 📁 Added
- _No new files added in this PR_

---

### 🛠️ How to Test
1. **Login** with role `BusinessManager` to get JWT token
2. Send request to:
   - `DELETE /api/businessbuyers/{buyerId}`
   - Header: `Authorization: Bearer {token}`
3. Ensure:
   - Only the creator BusinessManager can delete the buyer
   - Others receive 404 or permission errors

---

### 🧪 Test Cases
- ✅ Delete by correct BusinessManager: success, record removed
- ❌ Delete by another BusinessManager: blocked with 404 or forbidden
- ❌ Delete already-deleted buyer: blocked with not found
- ❌ Delete when not logged in: unauthorized

---

### 🔍 Notes
- Uses `User.GetUserId()` to extract manager identity from JWT
- Prevents deletion of records not owned by current manager
- Consistent with permission logic used in `GetAll()` and `GetById()`
- Does not affect Admin (restricted to BusinessManager-only role)

---

### 🔗 Related
- Modules: `BusinessBuyer`, `UserAccount`, `BusinessManager`
- Roles: `BusinessManager`
