### PR TITLE
refactor(business-buyer): enforce access control in SoftDelete API to ensure buyer belongs to current BusinessManager

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessBuyersController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessBuyersController.cs
@@ -180,7 +180,19 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [HttpPatch("soft-delete/{buyerId}")]
         public async Task<IActionResult> SoftDeleteBusinessBuyerByIdAsync(Guid buyerId)
         {
-            var result = await _businessBuyerService.SoftDeleteBusinessBuyerById(buyerId);
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
+            var result = await _businessBuyerService.SoftDeleteBusinessBuyerById(buyerId, userId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok("Xóa mềm thành công.");

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessBuyerService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessBuyerService.cs
@@ -20,6 +20,6 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> DeleteBusinessBuyerById(Guid buyerId, Guid userId);
 
-        Task<IServiceResult> SoftDeleteBusinessBuyerById(Guid buyerId);
+        Task<IServiceResult> SoftDeleteBusinessBuyerById(Guid buyerId, Guid userId);
     }
 }


### PR DESCRIPTION
## ☕ Feature: BusinessBuyer SoftDelete Authorization

### 📌 Objective
This PR refactors the **SoftDelete API for BusinessBuyer** to ensure that only the **BusinessManager who created the buyer** is authorized to soft delete it. It aligns with the security pattern applied in the hard delete and update APIs for consistent access control enforcement.

---

### ✅ Key Changes
- Refactored `SoftDeleteBusinessBuyerByIdAsync` controller method to extract `userId` from token and pass to service
- Updated `IBusinessBuyerService` and `BusinessBuyerService` to require `userId` and validate ownership before soft deletion
- Enforced logic that the BusinessBuyer must belong to the currently authenticated BusinessManager

---

### 🧱 Affected Files
- `BusinessBuyersController.cs`
- `IBusinessBuyerService.cs`
- `BusinessBuyerService.cs`

---

### 📁 Added
- ❌ *(No new files added)*

---

### 🛠️ How to Test
1. **Login** with role `BusinessManager` to obtain a valid JWT token  
2. Send a PATCH request to the endpoint:  
   - `PATCH /api/businessbuyers/soft-delete/{buyerId}`
   - Header: `Authorization: Bearer {token}`

---

### 🧪 Test Cases
- [x] ✅ Soft delete a buyer that belongs to the current BusinessManager → should return `200 OK`
- [x] ❌ Attempt to soft delete a buyer not created by the current manager → should return `404 Not Found`
- [x] ❌ Soft delete a non-existent buyer ID → should return `404 Not Found`

---

### 🔍 Notes
- 🛡️ Ensures consistent role-based access logic across delete & soft-delete
- ⚠️ If `BusinessManager` is not found from token, returns `401 Unauthorized`
- ⏱️ Uses `DateHelper.NowVietnamTime()` to set `UpdatedAt`

---

### 🔗 Related
- Modules: `BusinessBuyer`
- Roles: `BusinessManager`

---
