### PR TITLE
feat: implement GetAll ProcessingWaste with role-based access (Farmer/Admin)

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingWasteController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingWasteController.cs
@@ -1,0 +1,48 @@
+﻿using DakLakCoffeeSupplyChain.Common;
+using DakLakCoffeeSupplyChain.Services.IServices;
+using DakLakCoffeeSupplyChain.Services.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace DakLakCoffeeSupplyChain.APIService.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ProcessingWasteController : ControllerBase
+    {
+        private readonly IProcessingWasteService _processingWasteService;
+
+        public ProcessingWasteController(IProcessingWasteService processingWasteService)
+        {
+            _processingWasteService = processingWasteService;
+        }
+
+        // GET: api/processingwaste
+        [HttpGet]
+        [Authorize(Roles = "Farmer,Admin")]
+        public async Task<IActionResult> GetAll()
+        {
+            // Lấy userId từ token
+            var userIdStr = User.FindFirst("userId")?.Value
+                         ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            if (!Guid.TryParse(userIdStr, out var userId))
+                return BadRequest("Không thể lấy userId từ token.");
+
+            var isAdmin = User.IsInRole("Admin");
+
+            // Gọi Service
+            var result = await _processingWasteService.GetAllByUserIdAsync(userId, isAdmin);
+
+            // Trả kết quả
+            if (result.Status == Const.SUCCESS_READ_CODE)
+                return Ok(result.Data);
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound(result.Message);
+
+            return StatusCode(500, result.Message);
+        }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Program.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Program.cs
@@ -67,6 +67,7 @@ builder.Services.AddScoped<IAgriculturalExpertService, AgriculturalExpertService
 builder.Services.AddScoped<IOrderService, OrderService>();
 builder.Services.AddScoped<IOrderItemService, OrderItemService>();
 builder.Services.AddScoped<IInventoryLogService, InventoryLogService>();
+builder.Services.AddScoped<IProcessingWasteService, ProcessingWasteService>();
 
 //Add MemoryCache
 builder.Services.AddMemoryCache();

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcessingWastesDTOs/ProcessingWasteViewAllDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcessingWastesDTOs/ProcessingWasteViewAllDto.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.ProcessingWastesDTOs
+{
+    public class ProcessingWasteViewAllDto
+    {
+        public Guid WasteId { get; set; }
+        public string WasteCode { get; set; } = string.Empty;
+        public Guid ProgressId { get; set; }
+        public string WasteType { get; set; } = string.Empty;
+        public double Quantity { get; set; }
+        public string Unit { get; set; } = string.Empty;
+        public string Note { get; set; } = string.Empty;
+        public DateTime? RecordedAt { get; set; }
+        public string RecordedBy { get; set; } = string.Empty;
+        public bool IsDisposed { get; set; }
+        public DateTime? DisposedAt { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IProcessingBatchWasteRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IProcessingBatchWasteRepository.cs
@@ -1,0 +1,17 @@
+﻿using DakLakCoffeeSupplyChain.Repositories.Base;
+using DakLakCoffeeSupplyChain.Repositories.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
+{
+    public interface IProcessingBatchWasteRepository : IGenericRepository<ProcessingBatchWaste>
+    {
+        Task<List<ProcessingBatchWaste>> GetAllWastesAsync();
+        Task<ProcessingBatchWaste?> GetWasteByIdAsync(Guid wasteId);
+        Task<int> CountByProgressIdAsync(Guid progressId);
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ProcessingBatchWasteRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ProcessingBatchWasteRepository.cs
@@ -1,0 +1,46 @@
+﻿using DakLakCoffeeSupplyChain.Repositories.Base;
+using DakLakCoffeeSupplyChain.Repositories.DBContext;
+using DakLakCoffeeSupplyChain.Repositories.IRepositories;
+using DakLakCoffeeSupplyChain.Repositories.Models;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Repositories.Repositories
+{
+    public class ProcessingBatchWasteRepository : GenericRepository<ProcessingBatchWaste>, IProcessingBatchWasteRepository
+    {
+        public ProcessingBatchWasteRepository(DakLakCoffee_SCMContext context) : base(context)
+        {
+        }
+
+        public async Task<List<ProcessingBatchWaste>> GetAllWastesAsync()
+        {
+            return await _context.ProcessingBatchWastes
+                .Include(w => w.Progress)
+                   .ThenInclude(p => p.Stage)
+                .AsNoTracking()
+                .Where(w => !w.IsDeleted)
+                .OrderBy(w => w.CreatedAt)
+                .ToListAsync();
+        }
+
+        public async Task<ProcessingBatchWaste?> GetWasteByIdAsync(Guid wasteId)
+        {
+            return await _context.ProcessingBatchWastes
+                .Include(w => w.Progress)
+                   .ThenInclude(p => p.Stage)
+                .AsNoTracking()
+                .FirstOrDefaultAsync(w => w.WasteId == wasteId && !w.IsDeleted);
+        }
+
+        public async Task<int> CountByProgressIdAsync(Guid progressId)
+        {
+            return await _context.ProcessingBatchWastes
+                .CountAsync(w => w.ProgressId == progressId && !w.IsDeleted);
+        }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/IUnitOfWork.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/IUnitOfWork.cs
@@ -91,5 +91,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
         IOrderRepository OrderRepository { get; }
 
         IOrderItemRepository OrderItemRepository { get; }
+
+        IProcessingBatchWasteRepository ProcessingWasteRepository { get; }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/UnitOfWork.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/UnitOfWork/UnitOfWork.cs
@@ -53,6 +53,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
         private IAgriculturalExpertRepository? agriculturalExpertRepository;
         private IOrderRepository? orderRepository;
         private IOrderItemRepository? orderItemRepository;
+        private IProcessingBatchWasteRepository? processingWasteRepository;
 
         public UnitOfWork()
             => context ??= new DakLakCoffee_SCMContext();
@@ -347,12 +348,12 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
         }
         public IExpertAdviceRepository ExpertAdviceRepository
         {
-             get
+            get
             {
                 return expertAdviceRepository ??= new ExpertAdviceRepository(context);
             }
         }
-        
+
         public IAgriculturalExpertRepository AgriculturalExpertRepository
         {
             get
@@ -374,6 +375,14 @@ namespace DakLakCoffeeSupplyChain.Repositories.UnitOfWork
             get
             {
                 return orderItemRepository ??= new OrderItemRepository(context);
+            }
+        }
+
+        public IProcessingBatchWasteRepository ProcessingWasteRepository
+        {
+            get
+            {
+                return processingWasteRepository ??= new ProcessingBatchWasteRepository(context);
             }
         }
     }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingWasteService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingWasteService.cs
@@ -1,0 +1,14 @@
+﻿using DakLakCoffeeSupplyChain.Services.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Services.IServices
+{
+    public interface IProcessingWasteService
+    {
+        Task<IServiceResult> GetAllByUserIdAsync(Guid userId, bool isAdmin);
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/ProcessingBatchWasteMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/ProcessingBatchWasteMapper.cs
@@ -1,0 +1,35 @@
+﻿using DakLakCoffeeSupplyChain.Common.DTOs.ProcessingWastesDTOs;
+using DakLakCoffeeSupplyChain.Repositories.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+
+namespace DakLakCoffeeSupplyChain.Services.Mappers
+{
+    public static class ProcessingBatchWasteMapper
+    {
+        public static ProcessingWasteViewAllDto MapToViewAllDto(this ProcessingBatchWaste entity, string recordedByName)
+        {
+            return new ProcessingWasteViewAllDto
+            {
+                WasteId = entity.WasteId,
+                WasteCode = entity.WasteCode,
+                ProgressId = entity.ProgressId,
+                WasteType = entity.WasteType ?? string.Empty,
+                Quantity = entity.Quantity ?? 0,
+                Unit = entity.Unit ?? string.Empty,
+                Note = entity.Note ?? string.Empty,
+                RecordedAt = entity.RecordedAt,
+                RecordedBy = recordedByName,
+                IsDisposed = entity.IsDisposed ?? false,
+                DisposedAt = entity.DisposedAt,
+                CreatedAt = entity.CreatedAt,
+                UpdatedAt = entity.UpdatedAt
+            };
+        }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProcessingWasteService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProcessingWasteService.cs
@@ -1,0 +1,74 @@
+﻿using DakLakCoffeeSupplyChain.Common;
+using DakLakCoffeeSupplyChain.Common.DTOs.ProcessingWastesDTOs;
+using DakLakCoffeeSupplyChain.Repositories.UnitOfWork;
+using DakLakCoffeeSupplyChain.Services.Base;
+using DakLakCoffeeSupplyChain.Services.IServices;
+using DakLakCoffeeSupplyChain.Services.Mappers;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Services.Services
+{
+    public class ProcessingWasteService : IProcessingWasteService
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public ProcessingWasteService(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+        }
+
+        public async Task<IServiceResult> GetAllByUserIdAsync(Guid userId, bool isAdmin)
+        {
+            // Lấy toàn bộ danh sách người dùng để ánh xạ tên
+            var users = await _unitOfWork.UserAccountRepository.GetAllAsync(
+                predicate: u => !u.IsDeleted,
+                asNoTracking: true
+            );
+
+            var userMap = users.ToDictionary(u => u.UserId, u => u.Name);
+
+            // Bắt đầu truy vấn Waste
+            var query = _unitOfWork.ProcessingWasteRepository.GetAllQueryable()
+                .Where(w => !w.IsDeleted);
+
+            if (!isAdmin)
+            {
+                var farmer = await _unitOfWork.FarmerRepository.FindByUserIdAsync(userId);
+                if (farmer == null)
+                {
+                    return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Không tìm thấy Farmer tương ứng.");
+                }
+
+                // Lọc các ProgressId thuộc về farmer
+                var progressIds = await _unitOfWork.ProcessingBatchProgressRepository.GetAllQueryable()
+                    .Where(p => p.Batch.FarmerId == farmer.FarmerId)
+                    .Select(p => p.ProgressId)
+                    .ToListAsync();
+
+                query = query.Where(w => progressIds.Contains(w.ProgressId));
+            }
+
+            // Thực thi truy vấn
+            var wastes = await query.ToListAsync();
+
+            // Map sang DTO
+            var dtos = wastes.Select(waste =>
+            {
+                var recordedByName = waste.RecordedBy.HasValue && userMap.ContainsKey(waste.RecordedBy.Value)
+                    ? userMap[waste.RecordedBy.Value]
+                    : "N/A";
+
+                return waste.MapToViewAllDto(recordedByName);
+            }).ToList();
+
+            return new ServiceResult(Const.SUCCESS_READ_CODE, Const.SUCCESS_READ_MSG, dtos);
+        }
+
+
+    }
+}


### PR DESCRIPTION
## ☕ Feature: ProcessingWaste - API GetAll (Farmer/Admin)

### 📌 Objective
Implement the `GetAll` API for `ProcessingWaste`, allowing:
- **Admin**: to retrieve all waste records
- **Farmer**: to retrieve only wastes belonging to their own `Progress` entries

Goal: enforce role-based access control using `userId` and ensure correct data visibility based on roles.

---

### ✅ Key Changes
- Created `ProcessingWasteViewAllDto` for response formatting
- Added `ProcessingWasteMapper` to map from entity to DTO
- Implemented `GetAllByUserIdAsync(Guid, bool)` service logic with role-based filtering
- Optimized queries via `UserAccountRepository` and `ProcessingBatchProgressRepository`
- Created `ProcessingWasteController` with `GET /api/ProcessingWaste` endpoint

---

### 🧱 Affected Files
- `ProcessingWasteService.cs`
- `ProcessingWasteController.cs`
- `IProcessingWasteService.cs`
- `IProcessingWasteRepository.cs`
- `ProcessingWasteRepository.cs`
- `ProcessingWasteMapper.cs`
- `ProcessingWasteViewAllDto.cs`

---

### 📁 Added
- `ProcessingWasteViewAllDto.cs`
- `ProcessingWasteMapper.cs`

---

### 🛠️ How to Test
1. **Login** with the appropriate role:
   - `Admin` → should see all waste records
   - `Farmer` → should only see records linked to their own progresses
2. Send request:
   ```http
   GET /api/ProcessingWaste
   Header: Authorization: Bearer {token}
3.🧪 Test Cases
 ✅ Admin calls API → receives all records

 ✅ Farmer calls API → receives only own-related data

 ❌ Call without JWT → returns 401 Unauthorized

 ✅ No data found → returns 404 with appropriate message

4.🔍 Notes
Additional query to UserAccount used to resolve RecordedBy names

Fallback to "N/A" when RecordedBy is null or user not found

No .Include(u => u.User) used since ProcessingWaste lacks navigation properties — used dictionary lookup instead

6.🔗 Related
Modules: Processing, Waste

Roles: Admin, Farmer