### PR TITLE
refactor(product): enforce scoped deletion permission for BusinessManager in Delete API

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProductsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProductsController.cs
@@ -153,7 +153,19 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [Authorize(Roles = "BusinessManager")]
         public async Task<IActionResult> DeleteProductByIdAsync(Guid productId)
         {
-            var result = await _productService.DeleteProductById(productId);
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
+            var result = await _productService.DeleteProductById(productId, userId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok("Xóa thành công.");

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProductService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProductService.cs
@@ -18,7 +18,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Update(ProductUpdateDto productUpdateDto, Guid userId);
 
-        Task<IServiceResult> DeleteProductById(Guid productId);
+        Task<IServiceResult> DeleteProductById(Guid productId, Guid userId);
 
         Task<IServiceResult> SoftDeleteProductById(Guid productId);
     }


### PR DESCRIPTION
## ☕ Feature: Scoped Delete Permission for Product API

### 📌 Objective
Refactor `DeleteProductById` API to enforce scoped deletion logic for `BusinessManager`. This ensures that managers can only delete products either created by themselves or by staff under their supervision.

---

### ✅ Key Changes
- Refactored `ProductService.DeleteProductById` to include ownership and delegation checks
- Verified `CreatedBy` directly and validated staff-manager relationship via `SupervisorId`
- Cleaned up controller logic to pass `userId` from token
- Maintained role-based restriction via `[Authorize(Roles = "BusinessManager")]`

---

### 🧱 Affected Files
- `ProductsController.cs`
- `ProductService.cs`
- `IProductService.cs`

---

### 📁 Added
- *(None)* — logic added inside existing service method

---

### 🛠️ How to Test
1. **Login** as a `BusinessManager` to obtain JWT token
2. Send request to endpoint:
   - `DELETE /api/products/{productId}`
   - Header: `Authorization: Bearer {token}`
3. Expected outcomes vary by product ownership:
   - If created by same manager → ✅ allowed
   - If created by staff under this manager → ✅ allowed
   - If created by other staff/manager → ❌ forbidden

---

### 🧪 Test Cases
- [x] ✅ Delete product created by current manager — returns 200 OK  
- [x] ✅ Delete product created by staff managed by current manager — returns 200 OK  
- [x] ❌ Attempt to delete product created by unrelated staff — returns 404 or denied  
- [x] ❌ Attempt to delete with invalid productId — returns 404  

---

### 🔍 Notes
- Assumes `Product.CreatedBy` is a `UserId` (either from Manager or Staff)
- `BusinessStaff.SupervisorId` links to `BusinessManager.ManagerId` to determine ownership scope
- Role protection enforced at both controller and service levels

---

### 🔗 Related
- Modules: `Product`
- Roles: `BusinessManager`
