### PR TITLE
feat(outboundrequest): implement cancel request functionality for pen…

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/WarehouseOutboundRequestsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/WarehouseOutboundRequestsController.cs
@@ -95,5 +95,23 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             return StatusCode(500, result.Message);
         }
+        [HttpPut("{id}/cancel")]
+        [Authorize(Roles = "BusinessManager")]
+        public async Task<IActionResult> Cancel(Guid id)
+        {
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier);
+            if (userIdClaim == null || !Guid.TryParse(userIdClaim.Value, out Guid managerUserId))
+                return Unauthorized("Cannot determine user from token.");
+
+            var result = await _requestService.CancelRequestAsync(id, managerUserId);
+
+            if (result.Status == Const.SUCCESS_UPDATE_CODE)
+                return Ok(new { message = result.Message });
+
+            if (result.Status == Const.FAIL_UPDATE_CODE)
+                return Conflict(result.Message);
+
+            return StatusCode(500, result.Message);
+        }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IWarehouseOutboundRequestService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IWarehouseOutboundRequestService.cs
@@ -14,6 +14,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> GetDetailAsync(Guid outboundRequestId);
         Task<IServiceResult> GetAllAsync(Guid userId);
         Task<IServiceResult> AcceptRequestAsync(Guid requestId, Guid staffUserId);
+        Task<IServiceResult> CancelRequestAsync(Guid requestId, Guid managerUserId);
     }
 
 }


### PR DESCRIPTION
☕ Feature: Cancel Outbound Request
📌 Objective
Add the ability for BusinessManager to cancel an outbound warehouse request when it is still in Pending status. This helps ensure flexibility in the logistics flow and prevents unnecessary processing of outdated or mistaken requests.

✅ Key Changes
Implemented CancelRequestAsync method in WarehouseOutboundRequestService.

Added new API endpoint PUT /api/WarehouseOutboundRequests/{id}/cancel in controller.

Added Cancelled to WarehouseOutboundRequestStatus enum.

Enforced permission: only the creator (manager) of the request can cancel.

Validated that only Pending requests are cancellable.

🧱 Affected Files
WarehouseOutboundRequestService.cs

WarehouseOutboundRequestsController.cs

IWarehouseOutboundRequestService.cs

WarehouseOutboundRequestStatus.cs

📁 Added
CancelRequestAsync method in service layer

API route: PUT /api/WarehouseOutboundRequests/{id}/cancel

🛠️ How to Test
Login with a BusinessManager account to obtain JWT token.

Send a request to:

PUT /api/WarehouseOutboundRequests/{id}/cancel

Header: Authorization: Bearer {token}

Ensure:

The request exists.

The manager is the original requester.

The status is Pending.

🧪 Test Cases
 ✅ Cancel a pending request successfully (status updated to Cancelled)

 ❌ Prevent cancel if request is already Accepted

 ❌ Prevent cancel by another manager who didn’t create the request

 ❌ Return 404 if request not found or is deleted

🔍 Notes
Used Status field instead of soft delete to preserve history of cancelled requests.

Ensure consistent role checking and ManagerId ownership validation.

Frontend should reflect Cancelled status and prevent further action on such requests.

💡 Future enhancement: add audit logging or cancellation reason.

🔗 Related
Modules: Warehouse, OutboundRequest

Roles: BusinessManager