### PR TITLE
feat(outbound): insert seed data for requests and receipts, update inventory and logs, increase receipt code length

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/DBContext/DakLakCoffee_SCMContext.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/DBContext/DakLakCoffee_SCMContext.cs
@@ -1878,7 +1878,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
             entity.Property(e => e.ExportedAt).HasColumnType("datetime");
             entity.Property(e => e.InventoryId).HasColumnName("InventoryID");
             entity.Property(e => e.OutboundReceiptCode)
-                .HasMaxLength(20)
+                .HasMaxLength(50)
                 .IsUnicode(false);
             entity.Property(e => e.OutboundRequestId).HasColumnName("OutboundRequestID");
             entity.Property(e => e.UpdatedAt)


### PR DESCRIPTION
## ☕ Feature: Outbound Seed & Schema Update

### 📌 Objective
Seed sample data for outbound requests and receipts to support B2B delivery flow. Ensure correct inventory deduction and logging. Update database schema to accommodate longer receipt codes.

---

### ✅ Key Changes
- Insert seed data into `WarehouseOutboundRequests` and `WarehouseOutboundReceipts`
- Deduct inventory accordingly and insert matching records into `InventoryLogs`
- Increase `OutboundReceiptCode` column length from `VARCHAR(20)` to `VARCHAR(50)`
- Update corresponding EF Core configuration in `DbContext`

---

### 🧱 Affected Files
- `DakLakCoffee_SCM.sql`
- `DakLakCoffee_SCMContext.cs`

---

### 📁 Added
- *(none in this commit)*

---

### 🛠️ How to Test
1. Open SQL Server and run the updated seed scripts
2. Verify:
   - A `WarehouseOutboundRequest` linked to a valid `Inventory` and `OrderItem` is inserted
   - A `WarehouseOutboundReceipt` is inserted and reflects the correct warehouse, batch, quantity, and staff
   - Inventory is reduced appropriately
   - A matching `InventoryLog` entry is created

---

### 🧪 Test Cases
- [x] ✅ Insert outbound request and receipt with valid links to warehouse, batch, and inventory  
- [x] ✅ Outbound receipt code exceeds 20 chars and is stored correctly  
- [x] ✅ Inventory quantity is decreased by exact outbound amount  
- [x] ✅ Log entry reflects correct action and reference  

---

### 🔍 Notes
- ⚠️ Be sure to update production DB schema before deploying
- Affects B2B delivery logic where order item triggers warehouse export
- EF Core model binding updated for `OutboundReceiptCode` max length

---

### 🔗 Related
- Modules: `Warehouse`, `Inventory`, `Order`, `Seed`
- Roles: `BusinessManager`, `WarehouseStaff`
