### PR TITLE
feat: Implement GetById API for ProcessingWaste with role-based access

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingWasteController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingWasteController.cs
@@ -44,5 +44,30 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             return StatusCode(500, result.Message);
         }
+
+        [HttpGet("{id}")]
+        [Authorize(Roles = "Farmer,Admin")]
+        public async Task<IActionResult> GetById(Guid id)
+        {
+            var userIdStr = User.FindFirst("userId")?.Value
+                         ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            if (!Guid.TryParse(userIdStr, out var userId))
+                return BadRequest("Không thể lấy userId từ token.");
+
+            var isAdmin = User.IsInRole("Admin");
+
+            var result = await _processingWasteService.GetByIdAsync(id, userId, isAdmin);
+
+            if (result.Status == Const.SUCCESS_READ_CODE)
+                return Ok(result.Data);
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound(result.Message);
+
+            return StatusCode(403, result.Message); // Trường hợp không có quyền
+        }
+
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcessingWastesDTOs/ProcessingWasteViewDetailsDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcessingWastesDTOs/ProcessingWasteViewDetailsDto.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.ProcessingWastesDTOs
+{
+    public class ProcessingWasteViewDetailsDto
+    {
+        public Guid WasteId { get; set; }
+        public string WasteCode { get; set; } = string.Empty;
+        public Guid ProgressId { get; set; }
+        public string WasteType { get; set; } = string.Empty;
+        public double Quantity { get; set; }
+        public string Unit { get; set; } = string.Empty;
+        public string Note { get; set; } = string.Empty;
+        public DateTime? RecordedAt { get; set; }
+        public string RecordedBy { get; set; } = string.Empty;
+        public bool IsDisposed { get; set; }
+        public DateTime? DisposedAt { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingWasteService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingWasteService.cs
@@ -1,4 +1,5 @@
-﻿using DakLakCoffeeSupplyChain.Services.Base;
+﻿using DakLakCoffeeSupplyChain.Common.DTOs.ProcessingWastesDTOs;
+using DakLakCoffeeSupplyChain.Services.Base;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,5 +11,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
     public interface IProcessingWasteService
     {
         Task<IServiceResult> GetAllByUserIdAsync(Guid userId, bool isAdmin);
+        Task<IServiceResult> GetByIdAsync(Guid wasteId, Guid userId, bool isAdmin);
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/ProcessingBatchWasteMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/ProcessingBatchWasteMapper.cs
@@ -31,5 +31,24 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 UpdatedAt = entity.UpdatedAt
             };
         }
+        public static ProcessingWasteViewDetailsDto MapToDetailsDto(this ProcessingBatchWaste waste, string recordedByName)
+        {
+            return new ProcessingWasteViewDetailsDto
+            {
+                WasteId = waste.WasteId,
+                WasteCode = waste.WasteCode ?? string.Empty,
+                ProgressId = waste.ProgressId,
+                WasteType = waste.WasteType ?? string.Empty,
+                Quantity = waste.Quantity ?? 0,
+                Unit = waste.Unit ?? string.Empty,
+                Note = waste.Note ?? string.Empty,
+                RecordedAt = waste.RecordedAt,
+                RecordedBy = recordedByName,
+                IsDisposed = waste.IsDisposed ?? false,
+                DisposedAt = waste.DisposedAt,
+                CreatedAt = waste.CreatedAt,
+                UpdatedAt = waste.UpdatedAt
+            };
+        }
     }
 }


### PR DESCRIPTION
## ☕ Feature: Get ProcessingWaste by Id (Admin & Farmer)

### 📌 Objective
Implement the `GetById` API to retrieve a specific waste record with full validation and access control:
- Admin can retrieve all records
- Farmers can only access their own records via associated batches

---

### ✅ Key Changes
- ➕ Implemented `GetByIdAsync(Guid wasteId, Guid userId, bool isAdmin)` in `ProcessingWasteService`
- 🔐 Role-based permission: check `FarmerId` via `Progress → Batch`
- 🔄 Mapped `RecordedBy` to user's full name from `UserAccountRepository`
- 📥 Integrated into controller with endpoint: `GET /api/processingwaste/{id}`

---

### 🧱 Affected Files
- `ProcessingWasteService.cs`
- `IProcessingWasteService.cs`
- `ProcessingWasteController.cs`
- `ProcessingWasteMapper.cs`

---

### 📁 Added
- `GetByIdAsync` service method
- Controller route for `GET /api/processingwaste/{id}`

---

### 🛠️ How to Test
1. **Login** as Admin or Farmer to retrieve JWT token
2. Send GET request to:GET /api/processingwaste/{wasteId}
Authorization: Bearer {your_token}
3. Check:
- ✅ Admin can view any waste
- ✅ Farmer can only view their own
- ❌ Invalid `wasteId` returns NotFound
- ❌ Farmer requesting another user’s record gets Access Denied

---

### 🧪 Test Cases
- [x] Admin gets valid waste successfully
- [x] Farmer gets their own waste successfully
- [x] Farmer blocked from accessing others' waste
- [x] Missing or invalid `wasteId` returns 404

---

### 🔍 Notes
- `RecordedBy` mapped from `UserId → Name` for audit clarity
- Use of `asNoTracking` for performance on read-only ops
- Handles all edge cases with clear messages

---

### 🔗 Related
- Module: `ProcessingWaste`, `ProcessingBatchProgress`, `UserAccount`
- Roles: `Admin`, `Farmer`

