### PR TITLE
refactor(product): add permission check to SoftDelete API to restrict deletion scope

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProductsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProductsController.cs
@@ -113,7 +113,7 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         // PUT api/<ProductsController>/{productId}
         [HttpPut("{productId}")]
         [Authorize(Roles = "BusinessManager,BusinessStaff")]
-        public async Task<IActionResult> UpdateContractDeliveryBatchAsync(Guid productId, [FromBody] ProductUpdateDto productUpdateDto)
+        public async Task<IActionResult> UpdateProductAsync(Guid productId, [FromBody] ProductUpdateDto productUpdateDto)
         {
             // So sánh route id với dto id để đảm bảo tính nhất quán
             if (productId != productUpdateDto.ProductId)
@@ -182,9 +182,21 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         // PATCH: api/<ProductsController>/soft-delete/{productId}
         [HttpPatch("soft-delete/{productId}")]
         [Authorize(Roles = "BusinessManager")]
-        public async Task<IActionResult> SoftDeleteUserAccountByIdAsync(Guid productId)
+        public async Task<IActionResult> SoftDeleteProductByIdAsync(Guid productId)
         {
-            var result = await _productService.SoftDeleteProductById(productId);
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
+            var result = await _productService.SoftDeleteProductById(productId, userId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok("Xóa mềm thành công.");

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProductService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProductService.cs
@@ -20,6 +20,6 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> DeleteProductById(Guid productId, Guid userId);
 
-        Task<IServiceResult> SoftDeleteProductById(Guid productId);
+        Task<IServiceResult> SoftDeleteProductById(Guid productId, Guid userId);
     }
 }


### PR DESCRIPTION
## ☕ Feature: SoftDelete Product API with Permission Check

### 📌 Objective
Enhance the existing SoftDelete API for products by adding permission validation. Only the product creator or a BusinessStaff under the current BusinessManager can soft-delete a product. This ensures scoped data access control and prevents unauthorized deletions.

---

### ✅ Key Changes
- Refactored `SoftDeleteProductById` service to include permission check against the current BusinessManager
- Updated controller to extract `userId` from token and pass to service
- Added `!IsDeleted` filtering when querying product to prevent duplicate deletion
- Improved response messages to reflect permission denial or success accurately

---

### 🧱 Affected Files
- `ProductsController.cs`
- `IProductService.cs`
- `ProductService.cs`

---

### 📁 Added
- *(No new files added)*

---

### 🛠️ How to Test
1. **Login** with a `BusinessManager` role account to get a valid JWT token
2. Send request to endpoint:
   - `PATCH /api/products/soft-delete/{productId}`
   - Header: `Authorization: Bearer {token}`
3. No body required for this PATCH request

---

### 🧪 Test Cases
- [x] ✅ Soft-delete product created by self: returns 200 and sets `IsDeleted = true`  
- [x] ❌ Soft-delete product created by staff of another manager: returns 404 with access denied message  
- [x] ❌ Soft-delete already deleted product: returns 404 not found  
- [x] ✅ Soft-delete product created by staff under current manager: returns 200 OK  

---

### 🔍 Notes
- Role-based access control implemented using claims and supervisor ID validation
- Soft-delete is non-destructive: only `IsDeleted` and `UpdatedAt` are changed
- ⚠️ This API is only accessible to `BusinessManager`, not `Admin` or `BusinessStaff`

---

### 🔗 Related
- Modules: `Product`, `BusinessManager`
- Roles: `BusinessManager`
