### PR TITLE
refactor(contract): enforce scoped deletion permission in Delete and SoftDelete APIs

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractsController.cs
@@ -138,6 +138,28 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [HttpDelete("{contractId}")]
         public async Task<IActionResult> DeleteContractByIdAsync(Guid contractId)
         {
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
+            // Kiểm tra quyền sở hữu hợp đồng
+            var ownershipCheck = await _contractService.GetById(contractId, userId);
+
+            if (ownershipCheck.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy hợp đồng hoặc bạn không có quyền truy cập.");
+
+            if (ownershipCheck.Status != Const.SUCCESS_READ_CODE)
+                return StatusCode(500, ownershipCheck.Message);
+
+            // Nếu vượt qua kiểm tra quyền, tiến hành xóa
             var result = await _contractService.DeleteContractById(contractId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
@@ -156,6 +178,28 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [HttpPatch("soft-delete/{contractId}")]
         public async Task<IActionResult> SoftDeleteContractByIdAsync(Guid contractId)
         {
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
+            // Kiểm tra quyền sở hữu hợp đồng
+            var ownershipCheck = await _contractService.GetById(contractId, userId);
+
+            if (ownershipCheck.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy hợp đồng hoặc bạn không có quyền truy cập.");
+
+            if (ownershipCheck.Status != Const.SUCCESS_READ_CODE)
+                return StatusCode(500, ownershipCheck.Message);
+
+            // Nếu vượt qua kiểm tra quyền, tiến hành xóa mềm
             var result = await _contractService.SoftDeleteContractById(contractId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)


### PR DESCRIPTION
## ☕ Feature: Enforce access control in contract deletion APIs

### 📌 Objective
Enhance security and permission control for contract deletion APIs. Only the owning `BusinessManager` can delete or soft-delete a contract. This applies to both `DELETE /api/contracts/{id}` and `PATCH /api/contracts/soft-delete/{id}` endpoints.

---

### ✅ Key Changes
- Refactor `DeleteContractByIdAsync` in `ContractsController` to validate user access using `GetById(...)` before performing deletion
- Apply the same scoped access logic to `SoftDeleteContractByIdAsync` for consistent protection
- Reuse existing `GetById(contractId, userId)` method for permission check (no changes required in service layer)
- Improve response messaging for unauthorized or inaccessible contract IDs

---

### 🧱 Affected Files
- `ContractsController.cs`

---

### 📁 Added
- *(No new files added)*

---

### 🛠️ How to Test
1. **Login** as a `BusinessManager` and obtain JWT token
2. Call the endpoints with valid and invalid contract ownership:
   - `DELETE /api/contracts/{contractId}`
   - `PATCH /api/contracts/soft-delete/{contractId}`
   - Header: `Authorization: Bearer {token}`
3. Observe response:
   - 200 OK if contract belongs to current BusinessManager
   - 404 Not Found if contract does not exist or belongs to another manager
   - 401 Unauthorized if token missing or invalid

---

### 🧪 Test Cases
- [x] ✅ Delete contract owned by current user → should succeed  
- [x] ❌ Attempt delete for contract owned by another BusinessManager → should return 404  
- [x] ✅ Soft delete contract within user's scope → should succeed  
- [x] ❌ Soft delete with missing token → should return 401 Unauthorized  

---

### 🔍 Notes
- No changes to service layer were needed; access control reused via existing `GetById(...)`
- Responses are unified to avoid leaking ownership information
- 💡 Potential follow-up: abstract common access check logic to a private method

---

### 🔗 Related
- Modules: `Contract`
- Roles: `BusinessManager`
