### PR TITLE
refactor(contract-delivery-batch): enforce scoped deletion permission for BusinessManager in Delete API

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractDeliveryBatchsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractDeliveryBatchsController.cs
@@ -153,7 +153,19 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [Authorize(Roles = "BusinessManager")]
         public async Task<IActionResult> DeleteContractByIdAsync(Guid deliveryBatchId)
         {
-            var result = await _contractDeliveryBatchService.DeleteContractDeliveryBatchById(deliveryBatchId);
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
+            var result = await _contractDeliveryBatchService.DeleteContractDeliveryBatchById(deliveryBatchId, userId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok("Xóa thành công.");

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractDeliveryBatchService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractDeliveryBatchService.cs
@@ -18,7 +18,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Update(ContractDeliveryBatchUpdateDto contractDeliveryBatchDto, Guid userId);
 
-        Task<IServiceResult> DeleteContractDeliveryBatchById(Guid deliveryBatchId);
+        Task<IServiceResult> DeleteContractDeliveryBatchById(Guid deliveryBatchId, Guid userId);
 
         Task<IServiceResult> SoftDeleteContractDeliveryBatchById(Guid deliveryBatchId);
     }


### PR DESCRIPTION
## ☕ Feature: Delete ContractDeliveryBatch API (Scoped Permission)

### 📌 Objective
Refactor and secure the `DeleteContractDeliveryBatchById` API to ensure that only the appropriate `BusinessManager` who owns the associated contract is allowed to delete it. This enhances data security and enforces domain-based access control.

---

### ✅ Key Changes
- Refactored `DeleteContractDeliveryBatchById` service method to include seller scope validation.
- Added user-based access control by resolving `ManagerId` from `userId` using `ClaimsHelper`.
- Applied contract ownership validation by checking `Contract.SellerId == managerId`.
- Updated Controller logic to retrieve `userId` from token and pass to service.

---

### 🧱 Affected Files
- `ContractDeliveryBatchsController.cs`
- `IContractDeliveryBatchService.cs`
- `ContractDeliveryBatchService.cs`

---

### 📁 Added
- *None*

---

### 🛠️ How to Test
1. **Login** with a valid `BusinessManager` account to retrieve JWT token.
2. Send a DELETE request to:
   - `DELETE /api/contractdeliverybatchs/{deliveryBatchId}`
   - Header: `Authorization: Bearer {token}`
3. The target `ContractDeliveryBatch` must:
   - Exist
   - Belong to a contract whose seller is the logged-in manager

---

### 🧪 Test Cases
- [x] ✅ **Authorized Deletion**: A `BusinessManager` deletes a delivery batch under their own contract → returns `200 OK`.
- [x] ❌ **Unauthorized Deletion**: A manager tries to delete a delivery batch not under their scope → returns `404 Not Found`.
- [x] ❌ **Invalid User**: Token is missing or invalid → returns `401 Unauthorized`.

---

### 🔍 Notes
- Enforced scoped access by reusing logic from `GetById` API to identify ownership.
- This aligns with existing role-based access pattern across modules.
- No database schema changes were made.

---

### 🔗 Related
- Modules: `ContractDeliveryBatch`, `Contract`
- Roles: `BusinessManager`, `BusinessStaff` (for reading only)

---
