### PR TITLE
feat(order): implement hard delete API with cascade removal of order items

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/OrdersController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/OrdersController.cs
@@ -78,6 +78,26 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             return StatusCode(500, result.Message);  // Lỗi hệ thống
         }
 
+        // DELETE api/<OrdersController>/{orderId}
+        [HttpDelete("{orderId}")]
+        [Authorize(Roles = "BusinessManager")]
+        public async Task<IActionResult> DeleteOrderByIdAsync(Guid orderId)
+        {
+            var result = await _orderService
+                .DeleteOrderById(orderId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok("Xóa thành công.");
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy đơn hàng cần xóa.");
+
+            if (result.Status == Const.FAIL_DELETE_CODE)
+                return Conflict("Xóa thất bại.");
+
+            return StatusCode(500, result.Message);
+        }
+
         // PATCH: api/<OrdersController>/soft-delete/{orderId}
         [HttpPatch("soft-delete/{orderId}")]
         [Authorize(Roles = "BusinessManager")]

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IOrderService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IOrderService.cs
@@ -13,6 +13,8 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> GetById(Guid orderId, Guid userId);
 
+        Task<IServiceResult> DeleteOrderById(Guid orderId);
+
         Task<IServiceResult> SoftDeleteOrderById(Guid orderId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ContractDeliveryBatchService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ContractDeliveryBatchService.cs
@@ -617,17 +617,18 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 }
                 else
                 {
-                    // Xóa từng ContractItem trước (nếu có)
+                    // Xóa từng ContractDeliveryItem trước (nếu có)
                     if (contractDeliveryBatch.ContractDeliveryItems != null && 
                         contractDeliveryBatch.ContractDeliveryItems.Any())
                     {
                         foreach (var item in contractDeliveryBatch.ContractDeliveryItems)
                         {
+                            // Xóa ContractDeliveryItem khỏi repository
                             await _unitOfWork.ContractDeliveryItemRepository.RemoveAsync(item);
                         }
                     }
 
-                    // Xóa ContractDeliveryItem  khỏi repository
+                    // Xóa ContractDeliveryBatch khỏi repository
                     await _unitOfWork.ContractDeliveryBatchRepository.RemoveAsync(contractDeliveryBatch);
 
                     // Lưu thay đổi


### PR DESCRIPTION
## ☕ Feature: Hard Delete Order API

### 📌 Objective
Implement an API that allows `BusinessManager` to permanently delete an `Order` along with its associated `OrderItems`, following the same pattern as existing hard delete APIs. This supports full data removal for specific use cases, separate from the soft delete logic.

---

### ✅ Key Changes
- Added `DeleteOrderById(Guid orderId)` in `OrderService` with full deletion logic
- Implemented cascade removal for related `OrderItems`
- Created controller endpoint `DELETE /api/orders/{orderId}` with proper role authorization
- Updated `IOrderService` interface to include the new method

---

### 🧱 Affected Files
- `OrdersController.cs`
- `OrderService.cs`
- `IOrderService.cs`
- `ContractDeliveryBatchService.cs` (minor cleanup/update)

---

### 📁 Added
- *(No new files added)*

---

### 🛠️ How to Test
1. **Login** using a valid `BusinessManager` account to obtain a JWT token
2. Send a DELETE request to:
   - `DELETE /api/orders/{orderId}`
   - Header: `Authorization: Bearer {token}`
3. Ensure the `Order` and its `OrderItems` are fully removed from DB (or marked as deleted depending on implementation)

---

### 🧪 Test Cases
- [x] ✅ Delete existing order with items → success message returned
- [x] ✅ Delete existing order without items → still deleted successfully
- [x] ❌ Delete non-existent order → returns 404 not found
- [x] ❌ Delete with invalid role (e.g., Staff) → returns 403 forbidden

---

### 🔍 Notes
- Uses SoftDelete under the hood (via `RemoveAsync`) as per system-wide convention
- No new permission logic needed — relies on existing `BusinessManager` role check
- 🧩 Could be unified later under a shared `RemoveRangeAsync` method for performance

---

### 🔗 Related
- Modules: `Order`, `OrderItem`
- Roles: `BusinessManager`
