### PR TITLE
refactor(contract-delivery-item): enforce scoped creation permission for BusinessManager and Staff in Create API

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractDeliveryItemsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractDeliveryItemsController.cs
@@ -27,8 +27,20 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
             var result = await _contractDeliveryItemService
-                .Create(contractDeliveryItemCreateDto);
+                .Create(contractDeliveryItemCreateDto, userId);
 
             if (result.Status == Const.SUCCESS_CREATE_CODE)
                 return StatusCode(201, result.Data);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractDeliveryItemService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractDeliveryItemService.cs
@@ -10,7 +10,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 {
     public interface IContractDeliveryItemService
     {
-        Task<IServiceResult> Create(ContractDeliveryItemCreateDto contractDeliveryItemDto);
+        Task<IServiceResult> Create(ContractDeliveryItemCreateDto contractDeliveryItemDto, Guid userId);
 
         Task<IServiceResult> Update(ContractDeliveryItemUpdateDto contractDeliveryItemDto);
 


### PR DESCRIPTION
## ☕ Feature: ContractDeliveryItem - Scoped Creation API

### 📌 Objective
Add scoped permission control for the `Create` API of `ContractDeliveryItem`. Only `BusinessManager` or `BusinessStaff` (under a Manager) can create a delivery item if and only if the delivery batch belongs to their managed contract.

---

### ✅ Key Changes
- Enforced access control in `Create` method to resolve `userId → managerId` → `Contract.SellerId`
- Integrated `DeliveryBatch` ownership validation into repository predicate
- Added `userId` parameter to `Create` service and controller layer
- Maintained full logic for validation: contract item match, planned quantity constraint, duplicate check, and response DTO mapping

---

### 🧱 Affected Files
- `ContractDeliveryItemsController.cs`
- `ContractDeliveryItemService.cs`
- `IContractDeliveryItemService.cs`
- `ContractDeliveryItemCreateDto.cs`
- `ContractDeliveryItemMapping.cs`

---

### 📁 Added
- *(No new files – logic extended in existing service/controller)*

---

### 🛠️ How to Test
1. **Login** with a valid `BusinessManager` or `BusinessStaff` account to obtain JWT token.
2. Send a POST request to:
   - `POST /api/contractdeliveryitems`
   - Headers: `Authorization: Bearer {token}`
3. Sample request body:
```json
{
  "DeliveryBatchId": "GUID_HERE",
  "ContractItemId": "GUID_HERE",
  "PlannedQuantity": 1000,
  "Note": "Giao lần đầu tiên"
}
```

---

### 🧪 Test Cases
- [x] ✅ **Create a delivery item** when batch belongs to current manager → `201 Created`
- [x] ❌ **Create with invalid or unauthorized DeliveryBatch** → `403 Forbidden` or `404 Not Found`
- [x] ✅ **Detect duplicate `ContractItemId`** in the same batch → `409 Conflict`
- [x] ✅ **Reject if planned quantity exceeds contract** → `409 Conflict`
- [x] ❌ **Invalid role or missing token** → `401 Unauthorized`

---

### 🔍 Notes
- `Contract.SellerId` is validated via navigation property inside repository predicate
- `userId → managerId` mapping is reused from Delete API pattern
- DTO uses `IValidatableObject` to enforce `PlannedQuantity > 0` at model level
- ✅ No breaking changes to existing API routes or consumers

---

### 🔗 Related
- **Modules**: `Contract`, `DeliveryBatch`, `ContractItem`
- **Roles**: `BusinessManager`, `BusinessStaff`
