### PR TITLE
refactor(contract-delivery-item): enforce scoped update permission for BusinessManager and Staff in Update API

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractDeliveryItemsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ContractDeliveryItemsController.cs
@@ -65,8 +65,20 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
             var result = await _contractDeliveryItemService
-                .Update(contractDeliveryItemUpdate);
+                .Update(contractDeliveryItemUpdate, userId);
 
             if (result.Status == Const.SUCCESS_UPDATE_CODE)
                 return Ok(result.Data);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractDeliveryItemService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IContractDeliveryItemService.cs
@@ -12,7 +12,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
     {
         Task<IServiceResult> Create(ContractDeliveryItemCreateDto contractDeliveryItemDto, Guid userId);
 
-        Task<IServiceResult> Update(ContractDeliveryItemUpdateDto contractDeliveryItemDto);
+        Task<IServiceResult> Update(ContractDeliveryItemUpdateDto contractDeliveryItemDto, Guid userId);
 
         Task<IServiceResult> DeleteContractDeliveryItemById(Guid deliveryItemId, Guid userId);
 


### PR DESCRIPTION
## ☕ Feature: ContractDeliveryItem Update API

### 📌 Objective
Refactor Update API to enforce scoped access control based on the current authenticated user's role (BusinessManager or BusinessStaff). Ensure only authorized users can update contract delivery items they own or supervise.

---

### ✅ Key Changes
- Refactored `Update` service method to include `userId` and resolve `managerId` from current context
- Applied ownership check using `ContractItem.Contract.SellerId == managerId` to restrict update access
- Preserved existing validation logic: quantity constraint, duplicate item check, and contract consistency
- Updated controller to extract `userId` from JWT token and pass it to the service layer

---

### 🧱 Affected Files
- `ContractDeliveryItemsController.cs`
- `ContractDeliveryItemService.cs`
- `IContractDeliveryItemService.cs`

---

### 📁 Added
- *(No new files added)*

---

### 🛠️ How to Test
1. **Login** as `BusinessManager` or `BusinessStaff` to get a valid token  
2. Send a `PUT` request to:
   - `PUT /api/contractdeliveryitems/{deliveryItemId}`
   - Header: `Authorization: Bearer {token}`
3. Sample Body:
```json
{
  "deliveryItemId": "1a2b3c4d-1234-5678-9abc-def012345678",
  "contractItemId": "9f8e7d6c-4321-8765-ba09-fedcba098765",
  "plannedQuantity": 1200.0,
  "fulfilledQuantity": 300.0,
  "note": "Giao hàng đợt 1, cần kiểm tra chất lượng trước khi giao đợt 2."
}
```

---

### 🧪 Test Cases
- [x] ✅ **Update succeeds** when user owns the contract and input is valid  
- [x] ❌ **Update fails** when user is not authorized (wrong manager/staff)  
- [x] ❌ **Update fails** if quantity exceeds contract limit  
- [x] ❌ **Update fails** if duplicate item exists in the same delivery batch  

---

### 🔍 Notes
- EF Core tracking used correctly to update entities within unit of work  
- Scoped access is resolved via `SellerId` on related `ContractItem`  
- This refactor follows the same scoped access enforcement pattern as in `Delete` & `SoftDelete` APIs  

---

### 🔗 Related
- **Modules**: `ContractDeliveryItem`, `ContractItem`, `DeliveryBatch`  
- **Roles**: `BusinessManager`, `BusinessStaff`  
