### PR TITLE
fix(processing-batch): switch Status field to enum type

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingBatchsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcessingBatchsController.cs
@@ -80,8 +80,9 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             if (!Guid.TryParse(userIdStr, out var userId))
                 return BadRequest("Không thể lấy userId từ token.");
+            var isAdmin = User.IsInRole("Admin");
 
-            var result = await _processingbatchservice.UpdateAsync(dto, userId);
+            var result = await _processingbatchservice.UpdateAsync(dto, userId, isAdmin);
 
             if (result.Status == Const.SUCCESS_UPDATE_CODE)
                 return Ok(result.Data);
@@ -91,8 +92,8 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             return BadRequest(result.Message);
         }
-        [HttpDelete("{id}")]
-        [Authorize(Roles = "Farmer")]
+        [HttpPatch("{id}/soft-delete")]
+        [Authorize(Roles = "Farmer,Admin")]
         public async Task<IActionResult> SoftDelete(Guid id)
         {
             var userIdStr = User.FindFirst("userId")?.Value
@@ -101,7 +102,9 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             if (!Guid.TryParse(userIdStr, out var userId))
                 return BadRequest("Không thể lấy userId từ token.");
 
-            var result = await _processingbatchservice.SoftDeleteAsync(id, userId);
+            var isAdmin = User.IsInRole("Admin");
+
+            var result = await _processingbatchservice.SoftDeleteAsync(id, userId, isAdmin);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok(result.Message);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcessingBatchDTOs/ProcessingBatchDetailsDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcessingBatchDTOs/ProcessingBatchDetailsDto.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿using DakLakCoffeeSupplyChain.Common.DTOs.ProcessingBatchsProgressDTOs;
+using DakLakCoffeeSupplyChain.Common.DTOs.ProductDTOs;
+using DakLakCoffeeSupplyChain.Common.Enum.ProcessingEnums;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using DakLakCoffeeSupplyChain.Common.DTOs.ProductDTOs;
-using DakLakCoffeeSupplyChain.Common.DTOs.ProcessingBatchsProgressDTOs;
 
 namespace DakLakCoffeeSupplyChain.Common.DTOs.ProcessingBatchDTOs
 {
@@ -27,7 +28,7 @@ namespace DakLakCoffeeSupplyChain.Common.DTOs.ProcessingBatchDTOs
         public string InputUnit { get; set; }
 
         public double TotalOutputQuantity { get; set; }
-        public string Status { get; set; }
+        public ProcessingStatus Status { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime? UpdatedAt { get; set; }
 

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcessingBatchDTOs/ProcessingBatchUpdateDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcessingBatchDTOs/ProcessingBatchUpdateDto.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DakLakCoffeeSupplyChain.Common.Enum.ProcessingEnums;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -15,5 +16,6 @@ namespace DakLakCoffeeSupplyChain.Common.DTOs.ProcessingBatchDTOs
         public int MethodId { get; set; }
         public double InputQuantity { get; set; }
         public string InputUnit { get; set; }
+        public ProcessingStatus Status { get; set; }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcessingBatchDTOs/ProcessingBatchViewDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcessingBatchDTOs/ProcessingBatchViewDto.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DakLakCoffeeSupplyChain.Common.Enum.ProcessingEnums;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -23,7 +24,7 @@ namespace DakLakCoffeeSupplyChain.Common.DTOs.ProcessingBatchDTOs
         public double? TotalInputQuantity { get; set; }
         public double TotalOutputQuantity { get; set; }
 
-        public string Status { get; set; }
+        public ProcessingStatus Status { get; set; }
         public DateTime CreatedAt { get; set; }
     }
 

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/Enum/ProcessingEnums/ProcessingStatus.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/Enum/ProcessingEnums/ProcessingStatus.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Common.Enum.ProcessingEnums
+{
+    public enum ProcessingStatus
+    {
+        [Display(Name = "Chưa bắt đầu")]
+        NotStarted = 0,
+
+        [Display(Name = "Đang xử lý")]
+        InProgress = 1,
+
+        [Display(Name = "Hoàn thành")]
+        Completed = 2,
+
+        [Display(Name = "Đã hủy")]
+        Cancelled = 3
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingBatchService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcessingBatchService.cs
@@ -11,10 +11,10 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
     public interface IProcessingBatchService
     {
         Task<IServiceResult> GetAll();
-        Task<IServiceResult> GetAllByUserId(Guid userId, bool isAdmin = false);
+        Task<IServiceResult> GetAllByUserId(Guid userId, bool isAdmin = false, bool isManager = false);
         Task<IServiceResult> CreateAsync(ProcessingBatchCreateDto dto, Guid userId);
-        Task<IServiceResult> UpdateAsync(ProcessingBatchUpdateDto dto, Guid userId);
-        Task<IServiceResult> SoftDeleteAsync(Guid batchId, Guid userId);
+        Task<IServiceResult> UpdateAsync(ProcessingBatchUpdateDto dto, Guid userId, bool isAdmin);
+        Task<IServiceResult> SoftDeleteAsync(Guid batchId, Guid userId, bool isAdmin);
         Task<IServiceResult> HardDeleteAsync(Guid batchId, Guid userId);
         Task<IServiceResult> GetByIdAsync(Guid batchId, Guid userId, bool isAdmin);
     }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/ProcessingBatchMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/ProcessingBatchMapper.cs
@@ -1,8 +1,9 @@
 ﻿using DakLakCoffeeSupplyChain.Common.DTOs.ProcessingBatchDTOs;
 using DakLakCoffeeSupplyChain.Common.DTOs.ProcessingBatchsProgressDTOs;
 using DakLakCoffeeSupplyChain.Common.DTOs.ProcessingParameterDTOs;
-using DakLakCoffeeSupplyChain.Common.DTOs.ProductDTOs;
 using DakLakCoffeeSupplyChain.Common.DTOs.ProcessingParameterDTOs;
+using DakLakCoffeeSupplyChain.Common.DTOs.ProductDTOs;
+using DakLakCoffeeSupplyChain.Common.Enum.ProcessingEnums;
 using DakLakCoffeeSupplyChain.Repositories.Models;
 using System;
 using System.Collections.Generic;
@@ -34,7 +35,9 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 StageCount = entity.ProcessingBatchProgresses?.Count ?? 0,
                 TotalInputQuantity = entity.InputQuantity,
                 TotalOutputQuantity = 0,
-                Status = entity.Status,
+                Status = Enum.TryParse<ProcessingStatus>(entity.Status, out var statusEnum)
+                         ? statusEnum
+                         : ProcessingStatus.NotStarted,
                 CreatedAt = entity.CreatedAt ?? DateTime.MinValue
             };
         }
@@ -53,7 +56,9 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 MethodName = batch.Method?.Name,
                 InputQuantity = batch.InputQuantity,
                 InputUnit = batch.InputUnit,
-                Status = batch.Status,
+                Status = Enum.TryParse<ProcessingStatus>(batch.Status, out var statusEnum)
+            ? statusEnum
+            : ProcessingStatus.NotStarted,
                 CreatedAt = batch.CreatedAt ?? DateTime.MinValue,
                 UpdatedAt = batch.UpdatedAt,
 


### PR DESCRIPTION
## 🔧 fix(processing-batch): change status handling from string to enum

### 📝 Description
Refactored the `ProcessingBatch` logic to store and return `Status` as an enum (`ProcessingStatus`) instead of a string for improved type safety and consistency.

### ✅ Changes
- Updated `ProcessingBatch.Status` mapping to use `ProcessingStatus` enum
- Modified View DTOs (`ProcessingBatchViewDto`, `ProcessingBatchDetailsDto`) to reflect enum usage
- Adjusted mapper methods to parse enum properly and prevent runtime exceptions
- Ensured status enum value is sent to frontend as integer (int) instead of string

### 🧪 How to Test
- Test `GetAll`, `GetById`, and `Update` endpoints of `ProcessingBatch`
- Confirm that the `status` field in responses is an integer (e.g., 0, 1, 2, 3)
- Ensure no errors occur when mapping or parsing the status value

### 🔗 Related Files
- `ProcessingBatchViewDto.cs`
- `ProcessingBatchDetailsDto.cs`
- `ProcessingBatchMapper.cs`
- `ProcessingBatchService.cs`
