### PR TITLE
refactor(order-item): enforce scoped deletion for BusinessManager by validating userId

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/OrderItemsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/OrderItemsController.cs
@@ -1,5 +1,6 @@
 ﻿using DakLakCoffeeSupplyChain.Common;
 using DakLakCoffeeSupplyChain.Common.DTOs.OrderDTOs.OrderItemDTOs;
+using DakLakCoffeeSupplyChain.Common.Helpers;
 using DakLakCoffeeSupplyChain.Services.IServices;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -72,8 +73,20 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [Authorize(Roles = "BusinessManager")]
         public async Task<IActionResult> DeleteOrderItemByIdAsync(Guid orderItemId)
         {
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
             var result = await _orderItemService
-                .DeleteOrderItemById(orderItemId);
+                .DeleteOrderItemById(orderItemId, userId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok("Xóa thành công.");

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IOrderItemService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IOrderItemService.cs
@@ -14,7 +14,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Update(OrderItemUpdateDto orderItemUpdateDto);
 
-        Task<IServiceResult> DeleteOrderItemById(Guid orderItemId);
+        Task<IServiceResult> DeleteOrderItemById(Guid orderItemId, Guid userId);
 
         Task<IServiceResult> SoftDeleteOrderItemById(Guid orderItemId);
     }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/OrderItemService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/OrderItemService.cs
@@ -398,15 +398,32 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             }
         }
 
-        public async Task<IServiceResult> DeleteOrderItemById(Guid orderItemId)
+        public async Task<IServiceResult> DeleteOrderItemById(Guid orderItemId, Guid userId)
         {
             try
             {
+                // Tìm BusinessManager hiện tại từ userId
+                var manager = await _unitOfWork.BusinessManagerRepository.GetByIdAsync(
+                    predicate: m =>
+                       m.UserId == userId &&
+                       !m.IsDeleted,
+                    asNoTracking: true
+                );
+
+                if (manager == null)
+                {
+                    return new ServiceResult(
+                        Const.WARNING_NO_DATA_CODE,
+                        "Không tìm thấy BusinessManager tương ứng với tài khoản."
+                    );
+                }
+
                 // Tìm orderItem theo ID
                 var orderItem = await _unitOfWork.OrderItemRepository.GetByIdAsync(
                     predicate: oi => oi.OrderItemId == orderItemId,
                     include: query => query
-                           .Include(oi => oi.ContractDeliveryItem),
+                           .Include(oi => oi.ContractDeliveryItem)
+                           .Include(oi => oi.Order),
                     asNoTracking: false
                 );
 

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProductService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ProductService.cs
@@ -596,8 +596,8 @@ namespace DakLakCoffeeSupplyChain.Services.Services
 
                 // Tìm product theo ID
                 var product = await _unitOfWork.ProductRepository.GetByIdAsync(
-                    predicate: 
-                       p => p.ProductId == productId && 
+                    predicate: p => 
+                       p.ProductId == productId && 
                        !p.IsDeleted
                 );
 


### PR DESCRIPTION
## ☕ Feature: Refactor Delete OrderItem API

### 📌 Objective
Refactor the `DeleteOrderItemById` service to enforce scoped deletion by validating the `userId` of the current `BusinessManager`. This enhances access control even though `CreatedBy` is not available in `OrderItem`.

---

### ✅ Key Changes
- Updated `OrderItemService.DeleteOrderItemById()` to include `userId`-based validation via `BusinessManager` lookup
- Included `Order` and `ContractDeliveryItem` in `OrderItem` query for potential future scoped logic
- Cleaned up error handling and improved separation of concern in controller and service layers

---

### 🧱 Affected Files
- `OrderItemsController.cs`
- `OrderItemService.cs`
- `IOrderItemService.cs`
- `ProductService.cs` *(minor related adjustment)*

---

### 📁 Added
- *(None)*

---

### 🛠️ How to Test
1. **Login** as a `BusinessManager` and obtain a valid JWT token
2. Send DELETE request to:
   - `DELETE /api/orderitems/{orderItemId}`
   - Header: `Authorization: Bearer {token}`

---

### 🧪 Test Cases
- [x] ✅ Delete an existing `OrderItem` by its ID with valid role → should return 200 OK  
- [x] ❌ Try deleting with an invalid or missing token → should return 401 Unauthorized  
- [x] ❌ Delete a non-existent `OrderItemId` → should return 404 NotFound  

---

### 🔍 Notes
- No `CreatedBy` field exists in `OrderItem` or `Order`, so scoped permission is limited to current role-based validation
- Can be extended later via `DeliveryBatch.BusinessManagerId` if more strict ownership is needed
- 💡 Consider adding `CreatedBy` to `Order` in a future migration for stricter access validation

---

### 🔗 Related
- Modules: `Order`, `OrderItem`, `ContractDeliveryItem`
- Roles: `BusinessManager`
