### PR TITLE
feat(Procurement plan) Implement Update procurement plan status API

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcurementPlansController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ProcurementPlansController.cs
@@ -164,8 +164,9 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             return StatusCode(500, result.Message);
         }
 
-        // PATCH api/<ProcurementPlan>/{planId}
+        // PATCH api/<ProcurementPlan>/Update/{planId}
         [HttpPatch("Update/{planId}")]
+        [Authorize(Roles = "BusinessManager")]
         public async Task<IActionResult> UpdateAsync(Guid planId,
             [FromBody] ProcurementPlanUpdateDto updateDto)
         {
@@ -186,6 +187,42 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             var result = await _procurementPlanService
                 .Update(updateDto, userId, planId);
+
+            if (result.Status == Const.SUCCESS_UPDATE_CODE)
+                return Ok(result.Data);
+
+            if (result.Status == Const.FAIL_UPDATE_CODE)
+                return Conflict(result.Message);
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy kế hoạch.");
+
+            return StatusCode(500, result.Message);
+        }
+
+        // PATCH api/<ProcurementPlan>/UpdateStatus/{planId}
+        [HttpPatch("UpdateStatus/{planId}")]
+        [Authorize(Roles = "BusinessManager")]
+        public async Task<IActionResult> UpdateStatusAsync(Guid planId,
+            [FromBody] ProcurementPlanUpdateStatusDto updateDto)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
+            var result = await _procurementPlanService
+                .UpdateStatus(updateDto, userId, planId);
 
             if (result.Status == Const.SUCCESS_UPDATE_CODE)
                 return Ok(result.Data);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcurementPlanDTOs/ProcurementPlanUpdateStatusDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/ProcurementPlanDTOs/ProcurementPlanUpdateStatusDto.cs
@@ -1,0 +1,9 @@
+﻿using DakLakCoffeeSupplyChain.Common.Enum.ProcurementPlanEnums;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.ProcurementPlanDTOs
+{
+    public class ProcurementPlanUpdateStatusDto
+    {
+        public ProcurementPlanStatus Status { get; set; }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/Enum/ProcurementPlanEnums/ProcurementPlanStatus.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/Enum/ProcurementPlanEnums/ProcurementPlanStatus.cs
@@ -1,11 +1,20 @@
 ﻿namespace DakLakCoffeeSupplyChain.Common.Enum.ProcurementPlanEnums
-{
+{ 
+    /// <summary>
+    /// Closed và cancelled khác nhau như thế nào?
+    /// Điểm chung:
+    /// - Có thể được kích hoạt khi status đang ở trạng thái open
+    /// - Ngay cả khi sản lượng đã được đăng ký vẫn chưa đủ, closed và cancelled vẫn có thể được kích hoạt
+    /// Điểm riêng:
+    /// - Closed: Có thể được cập nhật ngay sau khi plan đã đạt đủ sản lượng đăng ký
+    /// - Cancelled: Chỉ có thể được kích hoạt khi plan đó đang được mở vẫn chưa có cam kết nào
+    /// </summary>
     public enum ProcurementPlanStatus
     {
         Draft = -1,             // Bản nháp, dùng làm default
-        Open = 0,               // Trạng thái mở, cho phép đăng ký
-        Closed = 1,             // Trạng thái đóng, không cho phép đăng ký nữa
-        Cancelled = 2,          // Trạng thái hủy bỏ, không còn hiệu lực
-        Deleted = 3,            // Trạng thái xóa, không còn hiển thị
+        Open = 0,               // Trạng thái mở, cho phép đăng ký, trạng thái này chỉ được chuyển sang khi đang ở Draft
+        Closed = 1,             // Trạng thái đóng, không cho phép đăng ký nữa, trạng thái này chỉ được chuyển sang khi đang ở Open
+        Cancelled = 2,          // Trạng thái hủy bỏ, không còn hiệu lực, trạng thái này chỉ được chuyển sang khi đang ở Open và plan đó chưa có cam kết nào
+        Deleted = 3,            // Trạng thái xóa, không còn hiển thị, trạng thái này chỉ được chuyển sang khi đang ở Draft
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcurementPlanService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IProcurementPlanService.cs
@@ -12,5 +12,6 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> SoftDeleteById(Guid planId);
         Task<IServiceResult> Create(ProcurementPlanCreateDto procurementPlanDto, Guid userId);
         Task<IServiceResult> Update(ProcurementPlanUpdateDto procurementPlanDto, Guid userId, Guid planId);
+        Task<IServiceResult> UpdateStatus(ProcurementPlanUpdateStatusDto dto, Guid userId, Guid planId);
     }
 }


### PR DESCRIPTION
- Implement the Update Procurement Plan Status API to allow changing the status of an existing procurement plan.
- Support updating the `status` field with validation for allowed status values.
- Ensure the API handles state transitions correctly and prevents invalid updates.
- Improve feedback by providing clear responses and error handling for status updates.
- Enhance overall management of procurement plans by enabling quick status modifications.
