### PR TITLE
refactor(SQL, DBContext) Fix FarmingCommitmentsDetails did not references FarmingCommitments

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/DBContext/DakLakCoffee_SCMContext.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/DBContext/DakLakCoffee_SCMContext.cs
@@ -148,11 +148,11 @@ public partial class DakLakCoffee_SCMContext : DbContext
     {
         modelBuilder.Entity<AgriculturalExpert>(entity =>
         {
-            entity.HasKey(e => e.ExpertId).HasName("PK__Agricult__7EDB3A38F76C98C7");
+            entity.HasKey(e => e.ExpertId).HasName("PK__Agricult__7EDB3A38BD8DB2AF");
 
-            entity.HasIndex(e => e.UserId, "UQ__Agricult__1788CCAD4F47B561").IsUnique();
+            entity.HasIndex(e => e.UserId, "UQ__Agricult__1788CCAD87484960").IsUnique();
 
-            entity.HasIndex(e => e.ExpertCode, "UQ__Agricult__FAAD20A740EB138C").IsUnique();
+            entity.HasIndex(e => e.ExpertCode, "UQ__Agricult__FAAD20A794676D2B").IsUnique();
 
             entity.Property(e => e.ExpertId)
                 .HasDefaultValueSql("(newid())")
@@ -180,9 +180,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<BusinessBuyer>(entity =>
         {
-            entity.HasKey(e => e.BuyerId).HasName("PK__Business__4B81C1CAC340AA2E");
+            entity.HasKey(e => e.BuyerId).HasName("PK__Business__4B81C1CA4E8CD72F");
 
-            entity.HasIndex(e => e.BuyerCode, "UQ__Business__F658F187A6FAE4C3").IsUnique();
+            entity.HasIndex(e => e.BuyerCode, "UQ__Business__F658F187D32F1D49").IsUnique();
 
             entity.Property(e => e.BuyerId)
                 .HasDefaultValueSql("(newid())")
@@ -217,9 +217,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<BusinessManager>(entity =>
         {
-            entity.HasKey(e => e.ManagerId).HasName("PK__Business__3BA2AA81AF1BD204");
+            entity.HasKey(e => e.ManagerId).HasName("PK__Business__3BA2AA81734B2CA4");
 
-            entity.HasIndex(e => e.ManagerCode, "UQ__Business__634BE7D1447367CE").IsUnique();
+            entity.HasIndex(e => e.ManagerCode, "UQ__Business__634BE7D1D8046C36").IsUnique();
 
             entity.Property(e => e.ManagerId)
                 .HasDefaultValueSql("(newid())")
@@ -258,11 +258,11 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<BusinessStaff>(entity =>
         {
-            entity.HasKey(e => e.StaffId).HasName("PK__Business__96D4AAF719A9DDB0");
+            entity.HasKey(e => e.StaffId).HasName("PK__Business__96D4AAF7D10C3041");
 
-            entity.HasIndex(e => e.UserId, "UQ__Business__1788CCAD9160230E").IsUnique();
+            entity.HasIndex(e => e.UserId, "UQ__Business__1788CCAD944181B2").IsUnique();
 
-            entity.HasIndex(e => e.StaffCode, "UQ__Business__D83AD8125E32D81E").IsUnique();
+            entity.HasIndex(e => e.StaffCode, "UQ__Business__D83AD812E1B661E7").IsUnique();
 
             entity.Property(e => e.StaffId)
                 .HasDefaultValueSql("(newid())")
@@ -299,9 +299,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<CoffeeType>(entity =>
         {
-            entity.HasKey(e => e.CoffeeTypeId).HasName("PK__CoffeeTy__3B5BEB6484639042");
+            entity.HasKey(e => e.CoffeeTypeId).HasName("PK__CoffeeTy__3B5BEB6429737029");
 
-            entity.HasIndex(e => e.TypeCode, "UQ__CoffeeTy__3E1CDC7C9D2C8BE2").IsUnique();
+            entity.HasIndex(e => e.TypeCode, "UQ__CoffeeTy__3E1CDC7C841CBA71").IsUnique();
 
             entity.Property(e => e.CoffeeTypeId)
                 .HasDefaultValueSql("(newid())")
@@ -325,9 +325,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<Contract>(entity =>
         {
-            entity.HasKey(e => e.ContractId).HasName("PK__Contract__C90D3409F0B86A64");
+            entity.HasKey(e => e.ContractId).HasName("PK__Contract__C90D34092EE32008");
 
-            entity.HasIndex(e => e.ContractCode, "UQ__Contract__CBECF8334285D396").IsUnique();
+            entity.HasIndex(e => e.ContractCode, "UQ__Contract__CBECF833E3ECF18D").IsUnique();
 
             entity.Property(e => e.ContractId)
                 .HasDefaultValueSql("(newid())")
@@ -366,9 +366,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<ContractDeliveryBatch>(entity =>
         {
-            entity.HasKey(e => e.DeliveryBatchId).HasName("PK__Contract__0E96BE56A1B5A7D3");
+            entity.HasKey(e => e.DeliveryBatchId).HasName("PK__Contract__0E96BE56A947E1FA");
 
-            entity.HasIndex(e => e.DeliveryBatchCode, "UQ__Contract__4F2E5F615443C8A0").IsUnique();
+            entity.HasIndex(e => e.DeliveryBatchCode, "UQ__Contract__4F2E5F617B836BD3").IsUnique();
 
             entity.Property(e => e.DeliveryBatchId)
                 .HasDefaultValueSql("(newid())")
@@ -395,9 +395,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<ContractDeliveryItem>(entity =>
         {
-            entity.HasKey(e => e.DeliveryItemId).HasName("PK__Contract__6A62915D5EEDBF42");
+            entity.HasKey(e => e.DeliveryItemId).HasName("PK__Contract__6A62915DA0AD747A");
 
-            entity.HasIndex(e => e.DeliveryItemCode, "UQ__Contract__48F2E59518EE8A0C").IsUnique();
+            entity.HasIndex(e => e.DeliveryItemCode, "UQ__Contract__48F2E595A745C2E7").IsUnique();
 
             entity.Property(e => e.DeliveryItemId)
                 .HasDefaultValueSql("(newid())")
@@ -428,9 +428,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<ContractItem>(entity =>
         {
-            entity.HasKey(e => e.ContractItemId).HasName("PK__Contract__18D352153F98E4A1");
+            entity.HasKey(e => e.ContractItemId).HasName("PK__Contract__18D35215F78CA425");
 
-            entity.HasIndex(e => e.ContractItemCode, "UQ__Contract__83D4D898656772D0").IsUnique();
+            entity.HasIndex(e => e.ContractItemCode, "UQ__Contract__83D4D898CE10B928").IsUnique();
 
             entity.Property(e => e.ContractItemId)
                 .HasDefaultValueSql("(newid())")
@@ -461,7 +461,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<CropProgress>(entity =>
         {
-            entity.HasKey(e => e.ProgressId).HasName("PK__CropProg__BAE29C857C83803F");
+            entity.HasKey(e => e.ProgressId).HasName("PK__CropProg__BAE29C85DC52525A");
 
             entity.Property(e => e.ProgressId)
                 .HasDefaultValueSql("(newid())")
@@ -499,11 +499,11 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<CropSeason>(entity =>
         {
-            entity.HasKey(e => e.CropSeasonId).HasName("PK__CropSeas__675AF5E08DE43EC0");
+            entity.HasKey(e => e.CropSeasonId).HasName("PK__CropSeas__675AF5E033CB5E76");
 
-            entity.HasIndex(e => e.CommitmentId, "UQ__CropSeas__5360E89667BEAF59").IsUnique();
+            entity.HasIndex(e => e.CommitmentId, "UQ__CropSeas__5360E896DA39F6D3").IsUnique();
 
-            entity.HasIndex(e => e.CropSeasonCode, "UQ__CropSeas__D31201511C065407").IsUnique();
+            entity.HasIndex(e => e.CropSeasonCode, "UQ__CropSeas__D31201516F957165").IsUnique();
 
             entity.Property(e => e.CropSeasonId)
                 .HasDefaultValueSql("(newid())")
@@ -537,9 +537,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<CropSeasonDetail>(entity =>
         {
-            entity.HasKey(e => e.DetailId).HasName("PK__CropSeas__135C314D2AAD9118");
+            entity.HasKey(e => e.DetailId).HasName("PK__CropSeas__135C314DD026E0CC");
 
-            entity.HasIndex(e => e.CommitmentDetailId, "UQ__CropSeas__E043A8583D1EE196").IsUnique();
+            entity.HasIndex(e => e.CommitmentDetailId, "UQ__CropSeas__E043A858AEE492C2").IsUnique();
 
             entity.Property(e => e.DetailId)
                 .HasDefaultValueSql("(newid())")
@@ -571,9 +571,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<CropStage>(entity =>
         {
-            entity.HasKey(e => e.StageId).HasName("PK__CropStag__03EB7AF8CBCBE7D9");
+            entity.HasKey(e => e.StageId).HasName("PK__CropStag__03EB7AF8A02FA947");
 
-            entity.HasIndex(e => e.StageCode, "UQ__CropStag__7BFA4BE354692364").IsUnique();
+            entity.HasIndex(e => e.StageCode, "UQ__CropStag__7BFA4BE365BA0535").IsUnique();
 
             entity.Property(e => e.StageId).HasColumnName("StageID");
             entity.Property(e => e.CreatedAt)
@@ -591,9 +591,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<CultivationRegistration>(entity =>
         {
-            entity.HasKey(e => e.RegistrationId).HasName("PK__Cultivat__6EF588300DD75140");
+            entity.HasKey(e => e.RegistrationId).HasName("PK__Cultivat__6EF588302233F5BA");
 
-            entity.HasIndex(e => e.RegistrationCode, "UQ__Cultivat__A94D9FED8CD344AC").IsUnique();
+            entity.HasIndex(e => e.RegistrationCode, "UQ__Cultivat__A94D9FEDBA0A4562").IsUnique();
 
             entity.Property(e => e.RegistrationId)
                 .HasDefaultValueSql("(newid())")
@@ -629,7 +629,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<CultivationRegistrationsDetail>(entity =>
         {
-            entity.HasKey(e => e.CultivationRegistrationDetailId).HasName("PK__Cultivat__B9AC84A6F8C3475A");
+            entity.HasKey(e => e.CultivationRegistrationDetailId).HasName("PK__Cultivat__B9AC84A64F26706A");
 
             entity.ToTable("CultivationRegistrationsDetail");
 
@@ -666,7 +666,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<ExpertAdvice>(entity =>
         {
-            entity.HasKey(e => e.AdviceId).HasName("PK__ExpertAd__4C842CE9F7E8D739");
+            entity.HasKey(e => e.AdviceId).HasName("PK__ExpertAd__4C842CE9208AD047");
 
             entity.ToTable("ExpertAdvice");
 
@@ -702,9 +702,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<Farmer>(entity =>
         {
-            entity.HasKey(e => e.FarmerId).HasName("PK__Farmers__731B88E80F3BCACE");
+            entity.HasKey(e => e.FarmerId).HasName("PK__Farmers__731B88E86F966472");
 
-            entity.HasIndex(e => e.FarmerCode, "UQ__Farmers__F4EF706270ECF626").IsUnique();
+            entity.HasIndex(e => e.FarmerCode, "UQ__Farmers__F4EF70622F23B5D9").IsUnique();
 
             entity.Property(e => e.FarmerId)
                 .HasDefaultValueSql("(newid())")
@@ -734,9 +734,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<FarmingCommitment>(entity =>
         {
-            entity.HasKey(e => e.CommitmentId).HasName("PK__FarmingC__5360E89768C45971");
+            entity.HasKey(e => e.CommitmentId).HasName("PK__FarmingC__5360E897D48D44C8");
 
-            entity.HasIndex(e => e.CommitmentCode, "UQ__FarmingC__04FF05668940E428").IsUnique();
+            entity.HasIndex(e => e.CommitmentCode, "UQ__FarmingC__04FF0566CF3481B4").IsUnique();
 
             entity.Property(e => e.CommitmentId)
                 .HasDefaultValueSql("(newid())")
@@ -757,6 +757,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
             entity.Property(e => e.Status)
                 .HasMaxLength(50)
                 .HasDefaultValue("Active");
+            entity.Property(e => e.TotalPrice).HasDefaultValue(0.0);
             entity.Property(e => e.UpdatedAt)
                 .HasDefaultValueSql("(getdate())")
                 .HasColumnType("datetime");
@@ -783,9 +784,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<FarmingCommitmentsDetail>(entity =>
         {
-            entity.HasKey(e => e.CommitmentDetailId).HasName("PK__FarmingC__E043A85975EB08B7");
+            entity.HasKey(e => e.CommitmentDetailId).HasName("PK__FarmingC__E043A8594BE3179F");
 
-            entity.HasIndex(e => e.CommitmentDetailCode, "UQ__FarmingC__E7E39EA60E93288B").IsUnique();
+            entity.HasIndex(e => e.CommitmentDetailCode, "UQ__FarmingC__E7E39EA659E9C25C").IsUnique();
 
             entity.Property(e => e.CommitmentDetailId)
                 .HasDefaultValueSql("(newid())")
@@ -793,6 +794,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
             entity.Property(e => e.CommitmentDetailCode)
                 .HasMaxLength(20)
                 .IsUnicode(false);
+            entity.Property(e => e.CommitmentId).HasColumnName("CommitmentID");
             entity.Property(e => e.ContractDeliveryItemId).HasColumnName("ContractDeliveryItemID");
             entity.Property(e => e.CreatedAt)
                 .HasDefaultValueSql("(getdate())")
@@ -802,6 +804,11 @@ public partial class DakLakCoffee_SCMContext : DbContext
             entity.Property(e => e.UpdatedAt)
                 .HasDefaultValueSql("(getdate())")
                 .HasColumnType("datetime");
+
+            entity.HasOne(d => d.Commitment).WithMany(p => p.FarmingCommitmentsDetails)
+                .HasForeignKey(d => d.CommitmentId)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("FK_FarmingCommitmentsDetails_CommitmentID");
 
             entity.HasOne(d => d.ContractDeliveryItem).WithMany(p => p.FarmingCommitmentsDetails)
                 .HasForeignKey(d => d.ContractDeliveryItemId)
@@ -820,9 +827,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<GeneralFarmerReport>(entity =>
         {
-            entity.HasKey(e => e.ReportId).HasName("PK__GeneralF__D5BD48E592DA1ABE");
+            entity.HasKey(e => e.ReportId).HasName("PK__GeneralF__D5BD48E54E9514AA");
 
-            entity.HasIndex(e => e.ReportCode, "UQ__GeneralF__0EDCD61435EE3862").IsUnique();
+            entity.HasIndex(e => e.ReportCode, "UQ__GeneralF__0EDCD614189551A4").IsUnique();
 
             entity.Property(e => e.ReportId)
                 .HasDefaultValueSql("(newid())")
@@ -868,9 +875,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<Inventory>(entity =>
         {
-            entity.HasKey(e => e.InventoryId).HasName("PK__Inventor__F5FDE6D345FE3808");
+            entity.HasKey(e => e.InventoryId).HasName("PK__Inventor__F5FDE6D3E285EB88");
 
-            entity.HasIndex(e => e.InventoryCode, "UQ__Inventor__E1E5B5D8D5FD4DB0").IsUnique();
+            entity.HasIndex(e => e.InventoryCode, "UQ__Inventor__E1E5B5D817CA1F3E").IsUnique();
 
             entity.Property(e => e.InventoryId)
                 .HasDefaultValueSql("(newid())")
@@ -903,7 +910,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<InventoryLog>(entity =>
         {
-            entity.HasKey(e => e.LogId).HasName("PK__Inventor__5E5499A8572E2EB1");
+            entity.HasKey(e => e.LogId).HasName("PK__Inventor__5E5499A8D6AFF50D");
 
             entity.Property(e => e.LogId)
                 .HasDefaultValueSql("(newid())")
@@ -925,7 +932,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<MediaFile>(entity =>
         {
-            entity.HasKey(e => e.MediaId).HasName("PK__MediaFil__B2C2B5AF8A977D47");
+            entity.HasKey(e => e.MediaId).HasName("PK__MediaFil__B2C2B5AF5712A809");
 
             entity.Property(e => e.MediaId)
                 .HasDefaultValueSql("(newid())")
@@ -957,9 +964,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<Order>(entity =>
         {
-            entity.HasKey(e => e.OrderId).HasName("PK__Orders__C3905BAF5E2EB388");
+            entity.HasKey(e => e.OrderId).HasName("PK__Orders__C3905BAF0FA52D3E");
 
-            entity.HasIndex(e => e.OrderCode, "UQ__Orders__999B52295FD27E4C").IsUnique();
+            entity.HasIndex(e => e.OrderCode, "UQ__Orders__999B522928DAA067").IsUnique();
 
             entity.Property(e => e.OrderId)
                 .HasDefaultValueSql("(newid())")
@@ -992,9 +999,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<OrderComplaint>(entity =>
         {
-            entity.HasKey(e => e.ComplaintId).HasName("PK__OrderCom__740D89AFFDB078E6");
+            entity.HasKey(e => e.ComplaintId).HasName("PK__OrderCom__740D89AF929380FD");
 
-            entity.HasIndex(e => e.ComplaintCode, "UQ__OrderCom__8144A1BAD82C1E56").IsUnique();
+            entity.HasIndex(e => e.ComplaintCode, "UQ__OrderCom__8144A1BA2835363D").IsUnique();
 
             entity.Property(e => e.ComplaintId)
                 .HasDefaultValueSql("(newid())")
@@ -1040,7 +1047,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<OrderItem>(entity =>
         {
-            entity.HasKey(e => e.OrderItemId).HasName("PK__OrderIte__57ED06A1A343A9BD");
+            entity.HasKey(e => e.OrderItemId).HasName("PK__OrderIte__57ED06A1A953C528");
 
             entity.Property(e => e.OrderItemId)
                 .HasDefaultValueSql("(newid())")
@@ -1074,9 +1081,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<Payment>(entity =>
         {
-            entity.HasKey(e => e.PaymentId).HasName("PK__Payments__9B556A583DF95E63");
+            entity.HasKey(e => e.PaymentId).HasName("PK__Payments__9B556A5843971F80");
 
-            entity.HasIndex(e => e.PaymentCode, "UQ__Payments__106D3BA897D0B72E").IsUnique();
+            entity.HasIndex(e => e.PaymentCode, "UQ__Payments__106D3BA8E6954BA3").IsUnique();
 
             entity.Property(e => e.PaymentId)
                 .HasDefaultValueSql("(newid())")
@@ -1119,7 +1126,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<PaymentConfiguration>(entity =>
         {
-            entity.HasKey(e => e.ConfigId).HasName("PK__PaymentC__C3BC333CCC0D32A0");
+            entity.HasKey(e => e.ConfigId).HasName("PK__PaymentC__C3BC333CCC48ABD1");
 
             entity.Property(e => e.ConfigId)
                 .HasDefaultValueSql("(newid())")
@@ -1145,9 +1152,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<ProcessingBatch>(entity =>
         {
-            entity.HasKey(e => e.BatchId).HasName("PK__Processi__5D55CE38450A190E");
+            entity.HasKey(e => e.BatchId).HasName("PK__Processi__5D55CE38E67A8DE6");
 
-            entity.HasIndex(e => e.SystemBatchCode, "UQ__Processi__6C2C6F5B469A8AC2").IsUnique();
+            entity.HasIndex(e => e.SystemBatchCode, "UQ__Processi__6C2C6F5BC6EECD2A").IsUnique();
 
             entity.Property(e => e.BatchId)
                 .HasDefaultValueSql("(newid())")
@@ -1192,9 +1199,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<ProcessingBatchEvaluation>(entity =>
         {
-            entity.HasKey(e => e.EvaluationId).HasName("PK__Processi__36AE68D38EF4C4EB");
+            entity.HasKey(e => e.EvaluationId).HasName("PK__Processi__36AE68D3BC6F6B16");
 
-            entity.HasIndex(e => e.EvaluationCode, "UQ__Processi__62264CFD0A0E6551").IsUnique();
+            entity.HasIndex(e => e.EvaluationCode, "UQ__Processi__62264CFD970CDD95").IsUnique();
 
             entity.Property(e => e.EvaluationId)
                 .ValueGeneratedNever()
@@ -1220,7 +1227,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<ProcessingBatchProgress>(entity =>
         {
-            entity.HasKey(e => e.ProgressId).HasName("PK__Processi__BAE29C851DFF8584");
+            entity.HasKey(e => e.ProgressId).HasName("PK__Processi__BAE29C85D9EBCFB2");
 
             entity.Property(e => e.ProgressId)
                 .HasDefaultValueSql("(newid())")
@@ -1263,9 +1270,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<ProcessingBatchWaste>(entity =>
         {
-            entity.HasKey(e => e.WasteId).HasName("PK__Processi__716E552139046511");
+            entity.HasKey(e => e.WasteId).HasName("PK__Processi__716E5521170DA77E");
 
-            entity.HasIndex(e => e.WasteCode, "UQ__Processi__424CD36EB39911A7").IsUnique();
+            entity.HasIndex(e => e.WasteCode, "UQ__Processi__424CD36E628F4966").IsUnique();
 
             entity.Property(e => e.WasteId)
                 .ValueGeneratedNever()
@@ -1294,9 +1301,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<ProcessingMethod>(entity =>
         {
-            entity.HasKey(e => e.MethodId).HasName("PK__Processi__FC681FB127BFFA2E");
+            entity.HasKey(e => e.MethodId).HasName("PK__Processi__FC681FB148694641");
 
-            entity.HasIndex(e => e.MethodCode, "UQ__Processi__11E9210D50B8E416").IsUnique();
+            entity.HasIndex(e => e.MethodCode, "UQ__Processi__11E9210DD24BBBCB").IsUnique();
 
             entity.Property(e => e.MethodId).HasColumnName("MethodID");
             entity.Property(e => e.CreatedAt)
@@ -1316,7 +1323,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<ProcessingParameter>(entity =>
         {
-            entity.HasKey(e => e.ParameterId).HasName("PK__Processi__F80C62972EAEB659");
+            entity.HasKey(e => e.ParameterId).HasName("PK__Processi__F80C629742968AF9");
 
             entity.Property(e => e.ParameterId)
                 .HasDefaultValueSql("(newid())")
@@ -1341,7 +1348,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<ProcessingStage>(entity =>
         {
-            entity.HasKey(e => e.StageId).HasName("PK__Processi__03EB7AF8CA3352B6");
+            entity.HasKey(e => e.StageId).HasName("PK__Processi__03EB7AF8E6C7EFF8");
 
             entity.Property(e => e.StageId).HasColumnName("StageID");
             entity.Property(e => e.CreatedAt)
@@ -1368,9 +1375,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<ProcessingWasteDisposal>(entity =>
         {
-            entity.HasKey(e => e.DisposalId).HasName("PK__Processi__206044C34A96E59D");
+            entity.HasKey(e => e.DisposalId).HasName("PK__Processi__206044C3CBF4235D");
 
-            entity.HasIndex(e => e.DisposalCode, "UQ__Processi__68D7C973891FE6F5").IsUnique();
+            entity.HasIndex(e => e.DisposalCode, "UQ__Processi__68D7C973C3CBDFF6").IsUnique();
 
             entity.Property(e => e.DisposalId)
                 .ValueGeneratedNever()
@@ -1402,9 +1409,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<ProcurementPlan>(entity =>
         {
-            entity.HasKey(e => e.PlanId).HasName("PK__Procurem__755C22D7F186A281");
+            entity.HasKey(e => e.PlanId).HasName("PK__Procurem__755C22D7DCAE92B5");
 
-            entity.HasIndex(e => e.PlanCode, "UQ__Procurem__DDC8069BA27C4832").IsUnique();
+            entity.HasIndex(e => e.PlanCode, "UQ__Procurem__DDC8069BBD5385D8").IsUnique();
 
             entity.Property(e => e.PlanId)
                 .HasDefaultValueSql("(newid())")
@@ -1434,9 +1441,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<ProcurementPlansDetail>(entity =>
         {
-            entity.HasKey(e => e.PlanDetailsId).HasName("PK__Procurem__ECEDC4CC88047C1C");
+            entity.HasKey(e => e.PlanDetailsId).HasName("PK__Procurem__ECEDC4CCB651FCBD");
 
-            entity.HasIndex(e => e.PlanDetailCode, "UQ__Procurem__020415ACE3E79DAA").IsUnique();
+            entity.HasIndex(e => e.PlanDetailCode, "UQ__Procurem__020415AC64898551").IsUnique();
 
             entity.Property(e => e.PlanDetailsId)
                 .HasDefaultValueSql("(newid())")
@@ -1482,9 +1489,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<Product>(entity =>
         {
-            entity.HasKey(e => e.ProductId).HasName("PK__Products__B40CC6ED7087F5E0");
+            entity.HasKey(e => e.ProductId).HasName("PK__Products__B40CC6ED1910D91F");
 
-            entity.HasIndex(e => e.ProductCode, "UQ__Products__2F4E024FFD102AE0").IsUnique();
+            entity.HasIndex(e => e.ProductCode, "UQ__Products__2F4E024F7E65B820").IsUnique();
 
             entity.Property(e => e.ProductId)
                 .HasDefaultValueSql("(newid())")
@@ -1546,7 +1553,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<Role>(entity =>
         {
-            entity.HasKey(e => e.RoleId).HasName("PK__Roles__8AFACE3A97079FAC");
+            entity.HasKey(e => e.RoleId).HasName("PK__Roles__8AFACE3A78EF3D5E");
 
             entity.Property(e => e.RoleId).HasColumnName("RoleID");
             entity.Property(e => e.CreatedAt)
@@ -1566,9 +1573,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<Shipment>(entity =>
         {
-            entity.HasKey(e => e.ShipmentId).HasName("PK__Shipment__5CAD378D16120C13");
+            entity.HasKey(e => e.ShipmentId).HasName("PK__Shipment__5CAD378DE5ECCCD0");
 
-            entity.HasIndex(e => e.ShipmentCode, "UQ__Shipment__E1167C21CFAE6D07").IsUnique();
+            entity.HasIndex(e => e.ShipmentCode, "UQ__Shipment__E1167C21F97116E9").IsUnique();
 
             entity.Property(e => e.ShipmentId)
                 .HasDefaultValueSql("(newid())")
@@ -1608,7 +1615,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<ShipmentDetail>(entity =>
         {
-            entity.HasKey(e => e.ShipmentDetailId).HasName("PK__Shipment__047142C01FD33B6D");
+            entity.HasKey(e => e.ShipmentDetailId).HasName("PK__Shipment__047142C083D3FD9A");
 
             entity.Property(e => e.ShipmentDetailId)
                 .HasDefaultValueSql("(newid())")
@@ -1638,7 +1645,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<SystemConfiguration>(entity =>
         {
-            entity.HasKey(e => e.Id).HasName("PK__SystemCo__3214EC07837420A3");
+            entity.HasKey(e => e.Id).HasName("PK__SystemCo__3214EC0723524422");
 
             entity.ToTable("SystemConfiguration");
 
@@ -1662,7 +1669,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<SystemConfigurationUser>(entity =>
         {
-            entity.HasKey(e => e.Id).HasName("PK__SystemCo__3214EC0719B67A03");
+            entity.HasKey(e => e.Id).HasName("PK__SystemCo__3214EC07A80F0B69");
 
             entity.Property(e => e.GrantedAt)
                 .HasDefaultValueSql("(getdate())")
@@ -1690,9 +1697,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<SystemNotification>(entity =>
         {
-            entity.HasKey(e => e.NotificationId).HasName("PK__SystemNo__20CF2E32841E150A");
+            entity.HasKey(e => e.NotificationId).HasName("PK__SystemNo__20CF2E322EFEC096");
 
-            entity.HasIndex(e => e.NotificationCode, "UQ__SystemNo__098D65DE0778EB31").IsUnique();
+            entity.HasIndex(e => e.NotificationCode, "UQ__SystemNo__098D65DE1FC4F345").IsUnique();
 
             entity.Property(e => e.NotificationId)
                 .HasDefaultValueSql("(newid())")
@@ -1713,7 +1720,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<SystemNotificationRecipient>(entity =>
         {
-            entity.HasKey(e => e.Id).HasName("PK__SystemNo__3214EC27441521F4");
+            entity.HasKey(e => e.Id).HasName("PK__SystemNo__3214EC2766DED309");
 
             entity.Property(e => e.Id)
                 .HasDefaultValueSql("(newid())")
@@ -1736,13 +1743,13 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<UserAccount>(entity =>
         {
-            entity.HasKey(e => e.UserId).HasName("PK__UserAcco__1788CCACE4FDC173");
+            entity.HasKey(e => e.UserId).HasName("PK__UserAcco__1788CCAC46E8C72B");
 
-            entity.HasIndex(e => e.UserCode, "UQ__UserAcco__1DF52D0C4276833E").IsUnique();
+            entity.HasIndex(e => e.UserCode, "UQ__UserAcco__1DF52D0CFE46D083").IsUnique();
 
-            entity.HasIndex(e => e.PhoneNumber, "UQ__UserAcco__85FB4E38EAA72500").IsUnique();
+            entity.HasIndex(e => e.PhoneNumber, "UQ__UserAcco__85FB4E38776770A9").IsUnique();
 
-            entity.HasIndex(e => e.Email, "UQ__UserAcco__A9D10534AB4B168E").IsUnique();
+            entity.HasIndex(e => e.Email, "UQ__UserAcco__A9D1053483C257A9").IsUnique();
 
             entity.Property(e => e.UserId)
                 .HasDefaultValueSql("(newid())")
@@ -1791,9 +1798,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<Wallet>(entity =>
         {
-            entity.HasKey(e => e.WalletId).HasName("PK__Wallets__84D4F92ECC59CFE6");
+            entity.HasKey(e => e.WalletId).HasName("PK__Wallets__84D4F92E619F94A7");
 
-            entity.HasIndex(e => e.UserId, "UQ__Wallets__1788CCADFE56F6E0").IsUnique();
+            entity.HasIndex(e => e.UserId, "UQ__Wallets__1788CCADF0A3991D").IsUnique();
 
             entity.Property(e => e.WalletId)
                 .HasDefaultValueSql("(newid())")
@@ -1813,7 +1820,7 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<WalletTransaction>(entity =>
         {
-            entity.HasKey(e => e.TransactionId).HasName("PK__WalletTr__55433A4B50F09E4D");
+            entity.HasKey(e => e.TransactionId).HasName("PK__WalletTr__55433A4BF0931652");
 
             entity.Property(e => e.TransactionId)
                 .HasDefaultValueSql("(newid())")
@@ -1840,9 +1847,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<Warehouse>(entity =>
         {
-            entity.HasKey(e => e.WarehouseId).HasName("PK__Warehous__2608AFD95E095B33");
+            entity.HasKey(e => e.WarehouseId).HasName("PK__Warehous__2608AFD9BB0CF54F");
 
-            entity.HasIndex(e => e.WarehouseCode, "UQ__Warehous__1686A05691247E6A").IsUnique();
+            entity.HasIndex(e => e.WarehouseCode, "UQ__Warehous__1686A056923E8FFC").IsUnique();
 
             entity.Property(e => e.WarehouseId)
                 .HasDefaultValueSql("(newid())")
@@ -1870,9 +1877,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<WarehouseInboundRequest>(entity =>
         {
-            entity.HasKey(e => e.InboundRequestId).HasName("PK__Warehous__70929FF594B05C4F");
+            entity.HasKey(e => e.InboundRequestId).HasName("PK__Warehous__70929FF5B05A01A6");
 
-            entity.HasIndex(e => e.InboundRequestCode, "UQ__Warehous__4EB81AC58AB5C879").IsUnique();
+            entity.HasIndex(e => e.InboundRequestCode, "UQ__Warehous__4EB81AC5CAB947BF").IsUnique();
 
             entity.Property(e => e.InboundRequestId)
                 .HasDefaultValueSql("(newid())")
@@ -1910,9 +1917,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<WarehouseOutboundReceipt>(entity =>
         {
-            entity.HasKey(e => e.OutboundReceiptId).HasName("PK__Warehous__0E3C50EEB3A23E60");
+            entity.HasKey(e => e.OutboundReceiptId).HasName("PK__Warehous__0E3C50EE7C822BB7");
 
-            entity.HasIndex(e => e.OutboundReceiptCode, "UQ__Warehous__CD7763FCA6FCF0D8").IsUnique();
+            entity.HasIndex(e => e.OutboundReceiptCode, "UQ__Warehous__CD7763FCCDC72746").IsUnique();
 
             entity.Property(e => e.OutboundReceiptId)
                 .HasDefaultValueSql("(newid())")
@@ -1960,9 +1967,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<WarehouseOutboundRequest>(entity =>
         {
-            entity.HasKey(e => e.OutboundRequestId).HasName("PK__Warehous__49E124906738D20E");
+            entity.HasKey(e => e.OutboundRequestId).HasName("PK__Warehous__49E12490C6CD66A0");
 
-            entity.HasIndex(e => e.OutboundRequestCode, "UQ__Warehous__DEE1D8221347B63D").IsUnique();
+            entity.HasIndex(e => e.OutboundRequestCode, "UQ__Warehous__DEE1D822847FB1B8").IsUnique();
 
             entity.Property(e => e.OutboundRequestId)
                 .HasDefaultValueSql("(newid())")
@@ -2009,9 +2016,9 @@ public partial class DakLakCoffee_SCMContext : DbContext
 
         modelBuilder.Entity<WarehouseReceipt>(entity =>
         {
-            entity.HasKey(e => e.ReceiptId).HasName("PK__Warehous__CC08C4009B7B96EB");
+            entity.HasKey(e => e.ReceiptId).HasName("PK__Warehous__CC08C40072A082D9");
 
-            entity.HasIndex(e => e.ReceiptCode, "UQ__Warehous__1AB76D0092BAFF47").IsUnique();
+            entity.HasIndex(e => e.ReceiptCode, "UQ__Warehous__1AB76D00A40A2102").IsUnique();
 
             entity.Property(e => e.ReceiptId)
                 .HasDefaultValueSql("(newid())")

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Models/FarmingCommitment.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Models/FarmingCommitment.cs
@@ -19,6 +19,8 @@ public partial class FarmingCommitment
 
     public Guid FarmerId { get; set; }
 
+    public double? TotalPrice { get; set; }
+
     public DateTime CommitmentDate { get; set; }
 
     public Guid? ApprovedBy { get; set; }
@@ -42,6 +44,8 @@ public partial class FarmingCommitment
     public virtual CropSeason CropSeason { get; set; }
 
     public virtual Farmer Farmer { get; set; }
+
+    public virtual ICollection<FarmingCommitmentsDetail> FarmingCommitmentsDetails { get; set; } = new List<FarmingCommitmentsDetail>();
 
     public virtual ProcurementPlan Plan { get; set; }
 

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Models/FarmingCommitmentsDetail.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Models/FarmingCommitmentsDetail.cs
@@ -11,6 +11,8 @@ public partial class FarmingCommitmentsDetail
 
     public string CommitmentDetailCode { get; set; }
 
+    public Guid CommitmentId { get; set; }
+
     public Guid RegistrationDetailId { get; set; }
 
     public Guid PlanDetailId { get; set; }
@@ -32,6 +34,8 @@ public partial class FarmingCommitmentsDetail
     public DateTime UpdatedAt { get; set; }
 
     public bool IsDeleted { get; set; }
+
+    public virtual FarmingCommitment Commitment { get; set; }
 
     public virtual ContractDeliveryItem ContractDeliveryItem { get; set; }
 


### PR DESCRIPTION
- Fix the missing reference between `FarmingCommitmentsDetails` and `FarmingCommitments` in the database context.
- Ensure proper foreign key relationship is established to maintain data integrity.
- Update the DBContext configuration to correctly map the relationship.
- Improve consistency and accuracy in data modeling for farming commitments.
- Prevent potential issues caused by lack of referential constraints in database operations.
