### PR TITLE
refactor(order): enforce scoped deletion permission for BusinessManager with seller validation

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/OrdersController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/OrdersController.cs
@@ -83,8 +83,20 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [Authorize(Roles = "BusinessManager")]
         public async Task<IActionResult> DeleteOrderByIdAsync(Guid orderId)
         {
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
             var result = await _orderService
-                .DeleteOrderById(orderId);
+                .DeleteOrderById(orderId, userId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok("Xóa thành công.");

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IOrderService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IOrderService.cs
@@ -13,7 +13,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> GetById(Guid orderId, Guid userId);
 
-        Task<IServiceResult> DeleteOrderById(Guid orderId);
+        Task<IServiceResult> DeleteOrderById(Guid orderId, Guid userId);
 
         Task<IServiceResult> SoftDeleteOrderById(Guid orderId);
     }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/OrderService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/OrderService.cs
@@ -186,15 +186,36 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             }
         }
 
-        public async Task<IServiceResult> DeleteOrderById(Guid orderId)
+        public async Task<IServiceResult> DeleteOrderById(Guid orderId, Guid userId)
         {
             try
             {
+                // Chỉ chấp nhận BusinessManager
+                var manager = await _unitOfWork.BusinessManagerRepository.GetByIdAsync(
+                    predicate: m => 
+                       m.UserId == userId && 
+                       !m.IsDeleted,
+                    asNoTracking: true
+                );
+
+                if (manager == null)
+                {
+                    return new ServiceResult(
+                        Const.FAIL_DELETE_CODE,
+                        "Bạn không phải BusinessManager nên không có quyền xóa đơn hàng."
+                    );
+                }
+
+                var managerId = manager.ManagerId;
+
                 // Tìm Order theo ID kèm danh sách OrderItems
                 var order = await _unitOfWork.OrderRepository.GetByIdAsync(
                     predicate: o =>
                        o.OrderId == orderId &&
-                       o.DeliveryBatch != null,
+                       !o.IsDeleted &&
+                       o.DeliveryBatch != null &&
+                       o.DeliveryBatch.Contract != null &&
+                       o.DeliveryBatch.Contract.SellerId == managerId,
                     include: query => query
                        .Include(o => o.OrderItems),
                     asNoTracking: false


### PR DESCRIPTION
## ☕ Feature: Delete Order with Scoped Permission

### 📌 Objective
Refactor the Delete Order API to strictly enforce scoped deletion permission. Ensures that only `BusinessManager` accounts can delete orders, and **only if the order belongs to their own enterprise**. This prevents unauthorized access to orders from other businesses.

---

### ✅ Key Changes
- Refactored `OrderService.DeleteOrderById` to validate ownership based on `Contract.SellerId == managerId`
- Enforced role check: only `BusinessManager` is allowed to delete orders
- Updated controller to maintain consistent authorization flow
- Protected against accidental or malicious deletion across enterprise boundaries

---

### 🧱 Affected Files
- `OrdersController.cs`
- `OrderService.cs`
- `IOrderService.cs`

---

### 📁 Added
- *(None)*

---

### 🛠️ How to Test
1. **Login** using a valid `BusinessManager` account to get a JWT token
2. Send DELETE request to:
   - `DELETE /api/orders/{orderId}`
   - Header: `Authorization: Bearer {token}`
3. Make sure the order to be deleted belongs to the same enterprise

---

### 🧪 Test Cases
- [x] ✅ Delete order created by the same BusinessManager: should return `200 OK`
- [x] ❌ Try deleting order of another enterprise: should return `404 Not Found`
- [x] ❌ Staff role calls DELETE: should be blocked by `403 Forbidden` (via `[Authorize]`)
- [x] ❌ Deleting a non-existent order: returns `404 Not Found`

---

### 🔍 Notes
- Ensures multi-tenant safety using `Contract.SellerId == managerId` check
- Only active (non-deleted) orders are eligible for deletion
- No soft-delete behavior involved — this is a hard delete with cascading removal of `OrderItems`

---

### 🔗 Related
- Modules: `Order`, `Contract`, `DeliveryBatch`, `OrderItem`
- Roles: `BusinessManager`
