### PR TITLE
refactor(order): enforce scoped soft-delete permission for BusinessManager with seller validation

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/OrdersController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/OrdersController.cs
@@ -115,8 +115,20 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [Authorize(Roles = "BusinessManager")]
         public async Task<IActionResult> SoftDeleteOrderByIdAsync(Guid orderId)
         {
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
             var result = await _orderService
-                .SoftDeleteOrderById(orderId);
+                .SoftDeleteOrderById(orderId, userId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok("Xóa mềm thành công.");

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IOrderService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IOrderService.cs
@@ -15,6 +15,6 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> DeleteOrderById(Guid orderId, Guid userId);
 
-        Task<IServiceResult> SoftDeleteOrderById(Guid orderId);
+        Task<IServiceResult> SoftDeleteOrderById(Guid orderId, Guid userId);
     }
 }


### PR DESCRIPTION
## ☕ Feature: Scoped Soft Delete for Order API

### 📌 Objective
Refactor the existing soft-delete logic for `Order` to enforce proper permission checks. This ensures that only `BusinessManager` users can soft-delete orders that belong to them (via associated `Contract.SellerId`).

---

### ✅ Key Changes
- Added `userId` validation via token in `SoftDeleteOrderByIdAsync` endpoint.
- Checked whether the user is a valid `BusinessManager` before processing deletion.
- Queried related `DeliveryBatch → Contract → SellerId` to enforce ownership.
- Marked both `Order` and its `OrderItems` as soft-deleted (`IsDeleted = true`).
- Updated timestamps and ensured changes are tracked properly by EF Core.

---

### 🧱 Affected Files
- `OrdersController.cs`
- `OrderService.cs`
- `IOrderService.cs`

---

### 📁 Added
- _(No new files added in this PR)_

---

### 🛠️ How to Test
1. **Login** using a valid `BusinessManager` account to obtain JWT token.
2. Send a PATCH request to the endpoint:
   - `PATCH /api/orders/soft-delete/{orderId}`
   - Header: `Authorization: Bearer {token}`
3. No request body needed.

---

### 🧪 Test Cases
- [x] ✅ Can soft-delete an order owned by the current BusinessManager  
- [x] ❌ Rejects deletion if user is not a BusinessManager  
- [x] ❌ Returns `404` if order is not found or already deleted  
- [x] ✅ Marks all related `OrderItems` as soft-deleted  

---

### 🔍 Notes
- Enforces ownership by checking `Contract.SellerId` against `manager.ManagerId`.
- Consistent logic reused from hard delete to maintain security parity.
- 💡 Can extract permission check into a shared helper for future reuse.

---

### 🔗 Related
- Modules: `Order`, `Contract`, `DeliveryBatch`
- Roles: `BusinessManager`
