### PR TITLE
feat(crop-season): cascade delete CropSeasonDetails and CropProgresse…

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropProgressRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropProgressRepository.cs
@@ -9,6 +9,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
 {
     public interface ICropProgressRepository : IGenericRepository<CropProgress>
     {
+        Task<List<CropProgress>> FindAsync(Expression<Func<CropProgress, bool>> predicate);
         Task<List<CropProgress>> GetAllWithIncludesAsync();
         Task<List<CropProgress>> GetByCropSeasonDetailIdWithIncludesAsync(Guid cropSeasonDetailId, Guid userId);
         Task<CropProgress?> GetByIdWithDetailAsync(Guid progressId);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropProgressRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropProgressRepository.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 namespace DakLakCoffeeSupplyChain.Repositories.Repositories
@@ -51,6 +52,12 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
                 .OrderBy(p => p.StageId)
                 .ThenBy(p => p.StepIndex ?? 0)
                 .ThenBy(p => p.ProgressDate)
+                .ToListAsync();
+        }
+        public async Task<List<CropProgress>> FindAsync(Expression<Func<CropProgress, bool>> predicate)
+        {
+            return await _context.CropProgresses
+                .Where(predicate)
                 .ToListAsync();
         }
 


### PR DESCRIPTION
## ☕ Feature: Cascade Delete Crop Season with Details and Progresses

### 📌 Objective
Allow both **hard delete** and **soft delete** of a Crop Season without restricting to “Cancelled” status. When a season is deleted, all related `CropSeasonDetails` and `CropProgresses` are also deleted or soft-deleted. This supports full cleanup and better flexibility for farmers and admins.

---

### ✅ Key Changes
- Removed restriction that crop season must be in "Cancelled" status before deletion.
- In `DeleteById`, delete all related `CropSeasonDetails` and their `CropProgresses`.
- In `SoftDeleteAsync`, mark all related details and progresses as `IsDeleted = true`.
- Updated permission check for owner (`Farmer`) or `Admin`.
- Added `FindAsync(predicate)` method in `CropProgressRepository` to fetch related progresses.

---

### 🧱 Affected Files
- `CropSeasonService.cs`
- `ICropProgressRepository.cs`
- `CropProgressRepository.cs`
- `CropSeasonController.cs`

---

### 📁 Added
- `FindAsync(Expression<Func<CropProgress, bool>> predicate)` in `CropProgressRepository`

---

### 🛠️ How to Test
1. **Login** as `Farmer` or `Admin`
2. Call one of the following endpoints:
   - `DELETE /api/cropseasons/{id}` → hard delete
   - `PUT /api/cropseasons/soft-delete/{id}` → soft delete
3. Confirm that:
   - All `CropSeasonDetails` are deleted or marked deleted
   - All `CropProgresses` under those details are also deleted/soft-deleted

---

### 🧪 Test Cases
- [x] ✅ Delete season (hard): all related details & progresses are removed from DB  
- [x] ✅ Soft delete season: `IsDeleted = true` for season, details, and progresses  
- [x] ❌ Try to delete as another user: should be blocked  
- [x] ✅ Delete season with no details: success  
- [x] ✅ Delete season with multiple details and progresses: all cascade properly  

---

### 🔍 Notes
- `FindAsync` was implemented only in `CropProgressRepository`, not in generic repository.
- No FK cascade configured in DB — handled manually in service layer.
- This improves user experience for farmers when seasons need to be reset or removed mid-cycle.

---

### 🔗 Related
- Modules: `CropSeason`, `CropSeasonDetail`, `CropProgress`
- Roles: `Farmer`, `Admin`

---
