### PR TITLE
feat(shipment-detail): implement hard delete API with validation, role check, and service result handling

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ShipmentDetailsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ShipmentDetailsController.cs
@@ -39,6 +39,26 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             return StatusCode(500, result.Message);
         }
 
+        // DELETE api/<ShipmentDetailsController>/{shipmentDetailId}
+        [HttpDelete("{shipmentDetailId}")]
+        [Authorize(Roles = "BusinessManager")]
+        public async Task<IActionResult> DeleteShipmentDetailByIdAsync(Guid shipmentDetailId)
+        {
+            var result = await _shipmentDetailService
+                .DeleteShipmentDetailById(shipmentDetailId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok("Xóa thành công.");
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Chi tiết đơn giao hàng không tồn tại hoặc đã bị xoá.");
+
+            if (result.Status == Const.FAIL_DELETE_CODE)
+                return Conflict("Xóa thất bại.");
+
+            return StatusCode(500, result.Message);
+        }
+
         // PATCH: api/<ShipmentDetailsController>/soft-delete/{shipmentDetailId}
         [HttpPatch("soft-delete/{shipmentDetailId}")]
         [Authorize(Roles = "BusinessManager")]

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IShipmentDetailService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IShipmentDetailService.cs
@@ -12,6 +12,8 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
     {
         Task<IServiceResult> Create(ShipmentDetailCreateDto shipmentDetailCreateDto);
 
+        Task<IServiceResult> DeleteShipmentDetailById(Guid shipmentDetailId);
+
         Task<IServiceResult> SoftDeleteShipmentDetailById(Guid shipmentDetailId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ShipmentDetailService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ShipmentDetailService.cs
@@ -168,6 +168,62 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             }
         }
 
+        public async Task<IServiceResult> DeleteShipmentDetailById(Guid shipmentDetailId)
+        {
+            try
+            {
+                // Tìm ShipmentDetail theo ID
+                var shipmentDetail = await _unitOfWork.ShipmentDetailRepository.GetByIdAsync(
+                    predicate: sd => sd.ShipmentDetailId == shipmentDetailId,
+                    include: query => query
+                           .Include(sd => sd.Shipment)
+                           .Include(sd => sd.OrderItem),
+                    asNoTracking: false
+                );
+
+                // Kiểm tra nếu không tồn tại
+                if (shipmentDetail == null)
+                {
+                    return new ServiceResult(
+                        Const.WARNING_NO_DATA_CODE,
+                        Const.WARNING_NO_DATA_MSG
+                    );
+                }
+                else
+                {
+                    // Xóa shipmentDetail khỏi repository
+                    await _unitOfWork.ShipmentDetailRepository.RemoveAsync(shipmentDetail);
+
+                    // Lưu thay đổi
+                    var result = await _unitOfWork.SaveChangesAsync();
+
+                    // Kiểm tra kết quả
+                    if (result > 0)
+                    {
+                        return new ServiceResult(
+                            Const.SUCCESS_DELETE_CODE,
+                            Const.SUCCESS_DELETE_MSG
+                        );
+                    }
+                    else
+                    {
+                        return new ServiceResult(
+                            Const.FAIL_DELETE_CODE,
+                            Const.FAIL_DELETE_MSG
+                        );
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Trả về lỗi nếu có exception
+                return new ServiceResult(
+                    Const.ERROR_EXCEPTION,
+                    ex.ToString()
+                );
+            }
+        }
+
         public async Task<IServiceResult> SoftDeleteShipmentDetailById(Guid shipmentDetailId)
         {
             try


### PR DESCRIPTION
## ☕ Feature: Hard Delete ShipmentDetail API

### 📌 Objective
Implement an API to **permanently delete** a `ShipmentDetail` by ID. This is distinct from the soft-delete logic and serves administrative cleanup use cases for the `BusinessManager` role.

---

### ✅ Key Changes
- Added `DELETE /api/shipmentdetails/{id}` endpoint in `ShipmentDetailsController`
- Implemented hard delete logic in `ShipmentDetailService` using EF tracking
- Used `ServiceResult` for unified response handling
- Enforced role restriction with `[Authorize(Roles = "BusinessManager")]`

---

### 🧱 Affected Files
- `ShipmentDetailsController.cs`
- `IShipmentDetailService.cs`
- `ShipmentDetailService.cs`

---

### 📁 Added
- ❌ *(No new files added in this commit)*

---

### 🛠️ How to Test
1. **Login** with `BusinessManager` role to get a valid JWT token
2. Send request to the endpoint:
   - `DELETE /api/shipmentdetails/{shipmentDetailId}`
   - Header: `Authorization: Bearer {token}`

---

### 🧪 Test Cases
- [x] ✅ Successfully hard delete a valid ShipmentDetail by ID  
- [x] ❌ Return `404 Not Found` if the ShipmentDetail does not exist  
- [x] ❌ Return `409 Conflict` if deletion fails (e.g., DB failure)  
- [x] ✅ Prevent unauthorized access for non-BusinessManager roles  

---

### 🔍 Notes
- Uses Entity Framework tracking for deletion  
- Separate from existing soft-delete logic  
- Result handling is centralized via `ServiceResult`  
- ⚠️ Should be used with caution as deletion is irreversible  

---

### 🔗 Related
- Modules: `Shipment`, `Order`, `Product`  
- Roles: `BusinessManager`

---
