### PR TITLE
feat(shipment): implement hard-delete API for Shipment and its details with validation and result handling

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ShipmentsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ShipmentsController.cs
@@ -1,6 +1,7 @@
 ﻿using DakLakCoffeeSupplyChain.Common;
 using DakLakCoffeeSupplyChain.Common.Helpers;
 using DakLakCoffeeSupplyChain.Services.IServices;
+using DakLakCoffeeSupplyChain.Services.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Query;
@@ -75,6 +76,38 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
                 return NotFound(result.Message);     // Trả 404 nếu không tìm thấy
 
             return StatusCode(500, result.Message);  // Lỗi hệ thống
+        }
+
+        // DELETE api/<ShipmentsController>/{shipmentId}
+        [HttpDelete("{shipmentId}")]
+        [Authorize(Roles = "BusinessManager")]
+        public async Task<IActionResult> DeleteShipmentByIdAsync(Guid shipmentId)
+        {
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
+            var result = await _shipmentService
+                .DeleteShipmentById(shipmentId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok("Xóa thành công.");
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy đơn giao hàng cần xóa.");
+
+            if (result.Status == Const.FAIL_DELETE_CODE)
+                return Conflict("Xóa thất bại.");
+
+            return StatusCode(500, result.Message);
         }
 
         // PATCH: api/<ShipmentsController>/soft-delete/{shipmentId}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IShipmentService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IShipmentService.cs
@@ -13,6 +13,8 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> GetById(Guid shipmentId, Guid userId);
 
+        Task<IServiceResult> DeleteShipmentById(Guid shipmentId);
+
         Task<IServiceResult> SoftDeleteShipmentById(Guid shipmentId);
     }
 }


### PR DESCRIPTION
## ☕ Feature: Delete Shipment (Hard-Delete API)

### 📌 Objective
Implement hard-delete functionality for Shipment and its related ShipmentDetails.  
This feature enables `BusinessManager` to permanently remove a shipment and all its nested shipment details via API.

---

### ✅ Key Changes
- Implemented `DeleteShipmentById(Guid shipmentId)` in `ShipmentService`
- Removed related `ShipmentDetails` before deleting `Shipment`
- Integrated with `IShipmentService` and `ShipmentsController`
- Added proper result handling via `ServiceResult` and status codes
- Applied `[Authorize(Roles = "BusinessManager")]` at controller level

---

### 🧱 Affected Files
- `ShipmentsController.cs`
- `IShipmentService.cs`
- `ShipmentService.cs`

---

### 📁 Added
- ❌ _No new files were added in this commit_

---

### 🛠️ How to Test
1. **Login** with a BusinessManager account and retrieve JWT token
2. Send DELETE request:
   - `DELETE /api/shipments/{shipmentId}`
   - Header: `Authorization: Bearer {token}`

---

### 🧪 Test Cases
- [x] ✅ Delete a valid shipment → returns `200 OK` with success message  
- [x] ❌ Delete non-existing shipment → returns `404 Not Found`  
- [x] ❌ Delete already-deleted shipment → returns `404 Not Found`  
- [x] ✅ Shipment with multiple shipmentDetails → all removed correctly  

---

### 🔍 Notes
- Currently does not check whether the manager owns the shipment (ownership validation will be added later)
- Assumes that `ShipmentDetails` are always deleted before `Shipment` (no orphaning risk)
- Future improvement: add scoped access validation based on `managerId` from token

---

### 🔗 Related
- Modules: `Shipment`, `Order`, `ShipmentDetails`
- Roles: `BusinessManager`
