### PR TITLE
refactor(shipment-detail): enforce scoped hard-delete by verifying manager's ownership via sellerId

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ShipmentDetailsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ShipmentDetailsController.cs
@@ -75,8 +75,20 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [Authorize(Roles = "BusinessManager")]
         public async Task<IActionResult> DeleteShipmentDetailByIdAsync(Guid shipmentDetailId)
         {
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
             var result = await _shipmentDetailService
-                .DeleteShipmentDetailById(shipmentDetailId);
+                .DeleteShipmentDetailById(shipmentDetailId, userId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok("Xóa thành công.");

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IShipmentDetailService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IShipmentDetailService.cs
@@ -14,7 +14,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Update(ShipmentDetailUpdateDto shipmentDetailUpdateDto);
 
-        Task<IServiceResult> DeleteShipmentDetailById(Guid shipmentDetailId);
+        Task<IServiceResult> DeleteShipmentDetailById(Guid shipmentDetailId, Guid userId);
 
         Task<IServiceResult> SoftDeleteShipmentDetailById(Guid shipmentDetailId, Guid userId);
     }


### PR DESCRIPTION
## ☕ Feature: Hard Delete ShipmentDetail by BusinessManager

### 📌 Objective
Refactor `DeleteShipmentDetailById` API to enforce scoped hard-delete by verifying that the `BusinessManager` owns the associated `Seller`. This prevents unauthorized deletion from other businesses.

---

### ✅ Key Changes
- Refactored `ShipmentDetailService.DeleteShipmentDetailById` to validate `SellerId` against the current `BusinessManager`
- Modified controller endpoint `DELETE /api/shipmentdetails/{id}` to pass `userId` from JWT claims
- Ensured navigation includes necessary relations (Contract → DeliveryBatch → Order → ShipmentDetail)
- Role-based enforcement: only `BusinessManager` can delete

---

### 🧱 Affected Files
- `ShipmentDetailsController.cs`
- `ShipmentDetailService.cs`
- `IShipmentDetailService.cs`

---

### 📁 Added
- _No new files added_

---

### 🛠️ How to Test
1. **Login** with role `BusinessManager` to get a JWT token
2. Send DELETE request to:
   - `DELETE /api/shipmentdetails/{shipmentDetailId}`
   - Header: `Authorization: Bearer {your_token}`
3. No body is required

---

### 🧪 Test Cases
- [x] ✅ Delete ShipmentDetail created by same BusinessManager → returns `200 OK`
- [x] ❌ Try deleting a ShipmentDetail created by another Seller → returns `404 Not Found`
- [x] ❌ Try deleting with a non-manager role (e.g., Staff) → returns `403 Forbidden`
- [x] ❌ Delete a non-existing ShipmentDetail → returns `404 Not Found`

---

### 🔍 Notes
- Scoped deletion logic leverages entity graph: `ShipmentDetail → Shipment → Order → DeliveryBatch → Contract → Seller`
- Ensures no data from other sellers is accessible across tenants
- Soft-delete was intentionally **not** used here; this is a true hard delete

---

### 🔗 Related
- Modules: `Shipment`, `Order`, `Contract`
- Roles: `BusinessManager`
