### PR TITLE
refactor(shipment): scoped soft-delete with SellerId check and related detail cleanup

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ShipmentsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/ShipmentsController.cs
@@ -115,8 +115,20 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
         [Authorize(Roles = "BusinessManager")]
         public async Task<IActionResult> SoftDeleteShipmentByIdAsync(Guid shipmentId)
         {
+            Guid userId;
+
+            try
+            {
+                // Lấy userId từ token qua ClaimsHelper
+                userId = User.GetUserId();
+            }
+            catch
+            {
+                return Unauthorized("Không xác định được userId từ token.");
+            }
+
             var result = await _shipmentService
-                .SoftDeleteShipmentById(shipmentId);
+                .SoftDeleteShipmentById(shipmentId, userId);
 
             if (result.Status == Const.SUCCESS_DELETE_CODE)
                 return Ok("Xóa mềm thành công.");

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IShipmentService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IShipmentService.cs
@@ -15,6 +15,6 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> DeleteShipmentById(Guid shipmentId);
 
-        Task<IServiceResult> SoftDeleteShipmentById(Guid shipmentId);
+        Task<IServiceResult> SoftDeleteShipmentById(Guid shipmentId, Guid userId);
     }
 }


### PR DESCRIPTION
## ☕ Feature: Scoped Soft-Delete for Shipment by BusinessManager

### 📌 Objective
Refactor the existing soft-delete logic of `Shipment` to enforce role-based access control.  
Only the **BusinessManager** who owns the shipment (via `SellerId`) is allowed to perform the deletion.  
Also ensures related `ShipmentDetails` are soft-deleted accordingly.

---

### ✅ Key Changes
- Refactored `SoftDeleteShipmentById` service method to validate `BusinessManager` by `UserId` and `SellerId`
- Soft-deleted all related `ShipmentDetails` alongside the parent shipment
- Added role-based endpoint in `ShipmentsController` restricted to `BusinessManager`

---

### 🧱 Affected Files
- `Controllers/ShipmentsController.cs`
- `Services/ShipmentService.cs`
- `Services/IShipmentService.cs`

---

### 📁 Added
- *(No new files added)*

---

### 🛠️ How to Test
1. **Login** using a BusinessManager account to get a valid **JWT token**
2. **Send request** to the endpoint:
- PATCH /api/shipments/soft-delete/{shipmentId}
- Header: Authorization: Bearer {token}

---

### 🧪 Test Cases
- ✅ Delete shipment as **correct BusinessManager** → success, shipment & details marked as `IsDeleted = true`
- ❌ Try deleting shipment from **another manager** → denied with proper error
- ❌ Try deleting an **already-deleted shipment** → handled gracefully with `NotFound` response

---

### 🔍 Notes
- Uses `Include(s => s.ShipmentDetails)` to soft-delete child entities
- Uses `User.GetUserId()` helper to extract `userId` from JWT claims
- Timestamp updates use `DateHelper.NowVietnamTime()`

---

### 🔗 Related
- **Modules**: `Shipment`, `ShipmentDetail`, `Order`, `Contract`
- **Roles**: `BusinessManager`
