### PR TITLE
feat(report): auto-resolve report when expert submits advice

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IGeneralFarmerReportRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IGeneralFarmerReportRepository.cs
@@ -11,5 +11,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
         Task<int> CountReportsInYearAsync(int year);
         Task<GeneralFarmerReport?> GetByIdEvenIfDeletedAsync(Guid reportId);
         Task<string?> GetMaxReportCodeForYearAsync(int year);
+        void Update(GeneralFarmerReport entity);
+
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/GeneralFarmerReportRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/GeneralFarmerReportRepository.cs
@@ -50,6 +50,10 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
                 .Select(r => r.ReportCode)
                 .FirstOrDefaultAsync();
         }
+        public void Update(GeneralFarmerReport entity)
+        {
+            _context.GeneralFarmerReports.Update(entity);
+        }
 
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ExpertAdviceService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/ExpertAdviceService.cs
@@ -81,7 +81,20 @@ public class ExpertAdviceService : IExpertAdviceService
         };
 
         await _unitOfWork.ExpertAdviceRepository.AddAsync(advice);
+
+        // ✅ Cập nhật trạng thái Resolve cho báo cáo nông dân
+        var reportToUpdate = await _unitOfWork.GeneralFarmerReportRepository.GetByIdAsync(dto.ReportId);
+        if (reportToUpdate != null && reportToUpdate.IsResolved != true)
+        {
+            reportToUpdate.IsResolved = true;
+            reportToUpdate.ResolvedAt = DateTime.UtcNow;
+            reportToUpdate.UpdatedAt = DateTime.UtcNow;
+
+            _unitOfWork.GeneralFarmerReportRepository.Update(reportToUpdate);
+        }
+
         await _unitOfWork.SaveChangesAsync();
+
 
         // 4. Trả lại kết quả chi tiết
         var savedAdvice = await _unitOfWork.ExpertAdviceRepository.GetByIdAsync(


### PR DESCRIPTION
## ☕ Feature: Auto-resolve Farmer Report on Expert Feedback

### 📌 Objective
Tự động cập nhật trạng thái `IsResolved` và `ResolvedAt` trong `GeneralFarmerReport` khi chuyên gia gửi phản hồi. Chức năng này thuộc luồng xử lý sự cố mùa vụ từ vai trò `AgriculturalExpert`.

---

### ✅ Key Changes
- Bổ sung `Update()` vào `IGeneralFarmerReportRepository` và implement trong repository
- Từ `ExpertAdviceService`, sau khi tạo phản hồi sẽ gọi cập nhật trạng thái báo cáo tương ứng
- Sửa `GeneralFarmerReportService` để chuẩn hóa cập nhật
- Cleanup code & tránh lỗi repository không có `Update()`

---

### 🧱 Affected Files
- `IGeneralFarmerReportRepository.cs`
- `GeneralFarmerReportRepository.cs`
- `ExpertAdviceService.cs`
- `GeneralFarmerReportService.cs`

---

### 📁 Added
- (Không có file mới, chỉ cập nhật logic trong các service/repo hiện tại)

---

### 🛠️ How to Test
1. **Đăng nhập** với tài khoản role `AgriculturalExpert`
2. Gửi POST request tới endpoint tạo phản hồi:
