### PR TITLE
feat(inbound-request): restrict request creation to completed batches…

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/WarehouseOutboundRequestRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/WarehouseOutboundRequestRepository.cs
@@ -22,6 +22,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
             return await _context.WarehouseOutboundRequests
                 .AsNoTracking()
                 .Include(r => r.Inventory)
+                .ThenInclude(inv => inv.Products)
                 .Include(r => r.Warehouse)
             .Include(r => r.RequestedByNavigation)
                 .FirstOrDefaultAsync(r => r.OutboundRequestId == id && !r.IsDeleted);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/WarehouseOutboundRequestMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/WarehouseOutboundRequestMapper.cs
@@ -36,7 +36,9 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 WarehouseId = entity.WarehouseId,
                 WarehouseName = entity.Warehouse?.Name,
                 InventoryId = entity.InventoryId,
-                InventoryName = entity.Inventory?.Products?.FirstOrDefault()?.ProductName,
+                InventoryName = entity.Inventory?.Products?.FirstOrDefault() != null
+    ? entity.Inventory.Products.First().ProductName
+    : null,
                 RequestedQuantity = entity.RequestedQuantity,
                 Unit = entity.Unit,
                 Purpose = entity.Purpose,

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/WarehouseOutboundRequestService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/WarehouseOutboundRequestService.cs
@@ -157,7 +157,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             await _unitOfWork.WarehouseOutboundRequests.CreateAsync(request);
             await _unitOfWork.SaveChangesAsync();
 
-            await _notificationService.NotifyOutboundRequestCreatedAsync(request.OutboundRequestId, manager.ManagerId);
+             _notificationService.NotifyOutboundRequestCreatedAsync(request.OutboundRequestId, manager.ManagerId);
 
             return new ServiceResult(Const.SUCCESS_CREATE_CODE, "Tạo yêu cầu xuất kho thành công", request.OutboundRequestId);
         }


### PR DESCRIPTION
☕ Feature: Warehouse Inbound Request Validation
📌 Objective
Enhance data integrity by restricting the creation of inbound warehouse requests to completed processing batches only, and ensuring that the total requested quantity does not exceed the actual quantity approved.

✅ Key Changes
✅ Enforce batch status check (Completed) before allowing request creation

✅ Filter out only Approved inbound requests when calculating total committed quantity

✅ Validate that the new request's quantity does not exceed the batch's remaining available quantity

✅ Improve user feedback with descriptive error messages

🧱 Affected Files
WarehouseInboundRequestService.cs

WarehouseInboundRequestCreateDto.cs

IWarehouseInboundRequestService.cs

(Optional) ProcessingEnums.cs if you added or referenced ProcessingStatus.Completed

📁 Added
❌ No new files added

🛠️ How to Test
Login as a Farmer and prepare a batch with Completed status

Use the API:

POST /api/warehouse-inbound-request

Header: Authorization: Bearer {token}

Sample Body:

json
Sao chép
Chỉnh sửa
{
  "batchId": "guid-of-completed-batch",
  "requestedQuantity": 1000,
  "preferredDeliveryDate": "2025-08-10",
  "note": "Inbound after processing completion"
}
🧪 Test Cases
 ✅ Valid Request: Request for a completed batch with valid remaining quantity

 ❌ Invalid Request: Request for a batch that is still processing or draft → should be rejected

 ❌ Over-committed Quantity: Requested quantity exceeds available → should be blocked

🔍 Notes
The validation now ensures only Approved requests are considered committed

Prevents overbooking from overlapping Pending requests

No DB schema change required (logic-only update)

🔗 Related
Modules: Warehouse, Processing, Batch, Request Validation

Roles: Farmer, BusinessStaff (approver)

