### PR TITLE
feat(outbound-receipt): implement GetSummaryAsync in WarehouseOutboun…

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/WarehouseInboundRequestsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/WarehouseInboundRequestsController.cs
@@ -72,28 +72,26 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
         [HttpGet]
         [Authorize(Roles = "BusinessStaff,Administrator")]
-        [EnableQuery]
         public async Task<IActionResult> GetAll()
         {
-            var userId = User.GetUserId();
+            try
+            {
+                var userId = User.GetUserId();
+                var result = await _service.GetAllAsync(userId);
 
-            var result = await _service
-                .GetAllAsync(userId);
+                if (result.Status == Const.SUCCESS_READ_CODE) return Ok(result);
+                if (result.Status == Const.WARNING_NO_DATA_CODE) return NotFound(result);
+                if (result.Status == Const.FAIL_UPDATE_CODE) return BadRequest(result);
 
-            if (result.Status == Const.SUCCESS_READ_CODE)
-                return Ok(result);
-
-            if (result.Status == Const.WARNING_NO_DATA_CODE)
-                return NotFound(result);
-
-            if (result.Status == Const.FAIL_UPDATE_CODE)
-                return BadRequest(result);
-
-            if (result.Status == Const.ERROR_EXCEPTION)
                 return StatusCode(500, result);
-
-            return StatusCode(500, result); // fallback
+            }
+            catch (Exception ex)
+            {
+                // luôn trả JSON
+                return StatusCode(500, new { status = Const.ERROR_EXCEPTION, message = ex.Message });
+            }
         }
+
 
         [HttpGet("{id}")]
         [Authorize(Roles = "BusinessStaff,Administrator,Farmer")]

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/WarehouseOutboundReceiptController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/WarehouseOutboundReceiptController.cs
@@ -110,5 +110,14 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             return StatusCode(500, result.Message);
         }
+        [HttpGet("{id}/summary")]
+        [Authorize(Roles = "BusinessStaff")]
+        public async Task<IActionResult> GetSummary(Guid id)
+        {
+            var result = await _receiptService.GetSummaryAsync(id);
+            if (result.Status == Const.SUCCESS_READ_CODE) return Ok(result.Data);
+            if (result.Status == Const.FAIL_READ_CODE) return NotFound(result.Message);
+            return StatusCode(500, result.Message);
+        }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IWarehouseOutboundReceiptService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IWarehouseOutboundReceiptService.cs
@@ -14,6 +14,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> ConfirmReceiptAsync(Guid receiptId, WarehouseOutboundReceiptConfirmDto dto);
         Task<IServiceResult> GetAllAsync(Guid userId);
         Task<IServiceResult> GetByIdAsync(Guid receiptId, Guid userId);
+        Task<IServiceResult> GetSummaryAsync(Guid requestId);
 
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/WarehouseOutboundReceiptMapper.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Mappers/WarehouseOutboundReceiptMapper.cs
@@ -23,10 +23,10 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
                 WarehouseId = dto.WarehouseId,
                 InventoryId = dto.InventoryId,
                 BatchId = batchId,
-                Quantity = dto.ExportedQuantity,
+                Quantity = dto.ExportedQuantity,                 // SL ghi nhận cho phiếu (draft)
                 ExportedBy = staffId,
                 ExportedAt = DateTime.UtcNow,
-                Note = dto.Note,
+                Note = dto.Note,                                  // Confirm sẽ append "[CONFIRMED:x]"
                 DestinationNote = "",
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow,
@@ -34,14 +34,16 @@ namespace DakLakCoffeeSupplyChain.Services.Mappers
             };
         }
 
+        // LƯU Ý: Không ghi đè Quantity nữa để hỗ trợ partial; chỉ append tag xác nhận
         public static void UpdateAfterConfirm(
             this WarehouseOutboundReceipt receipt,
             double confirmedQuantity,
             string? destinationNote)
         {
-            receipt.Quantity = confirmedQuantity;
-            receipt.DestinationNote = destinationNote ?? "";
-            receipt.Note = (receipt.Note ?? "") + $" [Đã xác nhận lúc {DateTime.UtcNow:HH:mm dd/MM/yyyy}]";
+            // Append tag xác nhận cho lần này
+            receipt.Note = (receipt.Note ?? "") + $" [CONFIRMED:{confirmedQuantity}]";
+            if (!string.IsNullOrWhiteSpace(destinationNote))
+                receipt.DestinationNote = destinationNote!;
             receipt.UpdatedAt = DateTime.UtcNow;
         }
 

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/WarehouseOutboundRequestService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/WarehouseOutboundRequestService.cs
@@ -30,61 +30,12 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             _codeGenerator = codeGenerator;
         }
 
-        //public async Task<IServiceResult> CreateRequestAsync(Guid managerUserId, WarehouseOutboundRequestCreateDto dto)
-        //{
-        //    var manager = await _unitOfWork.BusinessManagerRepository.FindByUserIdAsync(managerUserId);
-        //    if (manager == null)
-        //        return new ServiceResult(Const.FAIL_READ_CODE, "Không tìm thấy người dùng yêu cầu.");
-
-        //    // 🔍 Validate: kiểm tra tồn kho có đủ không
-        //    var inventory = await _unitOfWork.Inventories.GetByIdAsync(dto.InventoryId);
-        //    if (inventory == null || inventory.IsDeleted)
-        //        return new ServiceResult(Const.FAIL_READ_CODE, "Không tìm thấy thông tin tồn kho.");
-
-        //    if (inventory.WarehouseId != dto.WarehouseId)
-        //        return new ServiceResult(Const.ERROR_VALIDATION_CODE, "Tồn kho không thuộc kho được chọn.");
-
-        //    if (dto.RequestedQuantity <= 0)
-        //        return new ServiceResult(Const.ERROR_VALIDATION_CODE, "Số lượng yêu cầu phải lớn hơn 0.");
-
-        //    if (dto.RequestedQuantity > inventory.Quantity)
-        //        return new ServiceResult(Const.ERROR_VALIDATION_CODE,
-        //            $"Tồn kho hiện tại chỉ còn {inventory.Quantity:n0} {inventory.Unit}, không thể yêu cầu xuất {dto.RequestedQuantity:n0}.");
-
-        //    var generatedCode = await _codeGenerator.GenerateOutboundRequestCodeAsync();
-
-        //    var request = new WarehouseOutboundRequest
-        //    {
-        //        OutboundRequestId = Guid.NewGuid(),
-        //        OutboundRequestCode = generatedCode,
-        //        WarehouseId = dto.WarehouseId,
-        //        InventoryId = dto.InventoryId,
-        //        RequestedQuantity = dto.RequestedQuantity,
-        //        Unit = dto.Unit,
-        //        Purpose = dto.Purpose,
-        //        Reason = dto.Reason,
-        //        OrderItemId = dto.OrderItemId,
-        //        RequestedBy = manager.ManagerId,
-        //        Status = WarehouseOutboundRequestStatus.Pending.ToString(),
-        //        CreatedAt = DateTime.UtcNow,
-        //        UpdatedAt = DateTime.UtcNow,
-        //        IsDeleted = false
-        //    };
-
-        //    await _unitOfWork.WarehouseOutboundRequests.CreateAsync(request);
-        //    await _unitOfWork.SaveChangesAsync();
-
-        //    await _notificationService.NotifyOutboundRequestCreatedAsync(request.OutboundRequestId, manager.ManagerId);
-
-        //    return new ServiceResult(Const.SUCCESS_CREATE_CODE, "Tạo yêu cầu xuất kho thành công", request.OutboundRequestId);
-        //}
         public async Task<IServiceResult> CreateRequestAsync(Guid managerUserId, WarehouseOutboundRequestCreateDto dto)
         {
             var manager = await _unitOfWork.BusinessManagerRepository.FindByUserIdAsync(managerUserId);
             if (manager == null)
                 return new ServiceResult(Const.FAIL_READ_CODE, "Không tìm thấy người dùng yêu cầu.");
 
-            // 🔍 Validate tồn kho (gọi GetDetailByIdAsync để có Batch và CoffeeType)
             var inventory = await _unitOfWork.Inventories.GetDetailByIdAsync(dto.InventoryId);
             if (inventory == null || inventory.IsDeleted)
                 return new ServiceResult(Const.FAIL_READ_CODE, "Không tìm thấy thông tin tồn kho.");
@@ -99,57 +50,43 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 return new ServiceResult(Const.ERROR_VALIDATION_CODE,
                     $"Tồn kho hiện tại chỉ còn {inventory.Quantity:n0} {inventory.Unit}, không thể yêu cầu xuất {dto.RequestedQuantity:n0}.");
 
-            // ✅ Nếu có liên kết với OrderItem => kiểm tra vượt quá hợp đồng và loại cà phê
+            // Nếu gắn OrderItem → kiểm CoffeeType & hạn mức dựa trên receipts CONFIRMED
             if (dto.OrderItemId.HasValue)
             {
                 var orderItem = await _unitOfWork.OrderItemRepository.GetByIdAsync(
-                    predicate: oi =>
-                        oi.OrderItemId == dto.OrderItemId.Value &&
-                        !oi.IsDeleted,
+                    predicate: oi => oi.OrderItemId == dto.OrderItemId.Value && !oi.IsDeleted,
                     asNoTracking: true
                 );
-
                 if (orderItem == null)
                     return new ServiceResult(Const.FAIL_CREATE_CODE, "Không tìm thấy dòng đơn hàng tương ứng.");
 
-                // 🔍 Lấy Product để so sánh loại cà phê
                 var product = await _unitOfWork.ProductRepository.GetByIdAsync(orderItem.ProductId);
                 if (product == null)
                     return new ServiceResult(Const.FAIL_CREATE_CODE, "Không tìm thấy sản phẩm tương ứng trong đơn hàng.");
 
                 var productCoffeeTypeId = product.CoffeeTypeId;
                 var inventoryCoffeeTypeId = inventory.Batch?.CoffeeTypeId;
-
                 if (inventoryCoffeeTypeId == null)
                     return new ServiceResult(Const.FAIL_CREATE_CODE, "Không xác định được loại cà phê trong tồn kho.");
 
                 if (productCoffeeTypeId != inventoryCoffeeTypeId)
+                    return new ServiceResult(Const.ERROR_VALIDATION_CODE, "Loại cà phê trong tồn kho không khớp với sản phẩm trong đơn hàng.");
+
+                // Hạn mức theo confirmed receipts (không dựa vào Completed requests)
+                var receiptsByOrderItem = await _unitOfWork.WarehouseOutboundReceipts.GetByOrderItemIdAsync(orderItem.OrderItemId);
+                double totalConfirmedOrderItem = receiptsByOrderItem
+                    .SelectMany(r => ParseConfirmedFromNote(r.Note))
+                    .Sum();
+
+                var allowedQuantity = orderItem.Quantity ?? 0.0;
+                if (totalConfirmedOrderItem + dto.RequestedQuantity > allowedQuantity)
                 {
                     return new ServiceResult(Const.ERROR_VALIDATION_CODE,
-                        "Loại cà phê trong tồn kho không khớp với sản phẩm trong đơn hàng.");
-                }
-
-                // ⚠️ Tổng số lượng đã Completed (không tính Pending)
-                var completedRequests = await _unitOfWork.WarehouseOutboundRequests.GetAllAsync(
-                    predicate: r =>
-                        r.OrderItemId == dto.OrderItemId.Value &&
-                        !r.IsDeleted &&
-                        r.Status == WarehouseOutboundRequestStatus.Completed.ToString()
-                );
-
-                double totalCompleted = completedRequests.Sum(r => r.RequestedQuantity);
-                double allowedQuantity = orderItem.Quantity ?? 0.0;
-                double newQuantity = dto.RequestedQuantity;
-
-                if (totalCompleted + newQuantity > allowedQuantity)
-                {
-                    return new ServiceResult(Const.ERROR_VALIDATION_CODE,
-                        $"Số lượng yêu cầu vượt quá giới hạn hợp đồng ({allowedQuantity:n0}). " +
-                        $"Đã xuất: {totalCompleted:n0}, lần này: {newQuantity:n0}.");
+                        $"Số lượng yêu cầu vượt quá giới hạn đơn hàng ({allowedQuantity:n0}). Đã xác nhận: {totalConfirmedOrderItem:n0}, yêu cầu mới: {dto.RequestedQuantity:n0}.");
                 }
             }
 
-            // ✅ Tạo yêu cầu
+            // Tạo yêu cầu
             var requestId = Guid.NewGuid();
             var requestCode = await _codeGenerator.GenerateOutboundRequestCodeAsync();
             var request = dto.ToEntityCreate(requestId, requestCode, manager.ManagerId);
@@ -157,56 +94,41 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             await _unitOfWork.WarehouseOutboundRequests.CreateAsync(request);
             await _unitOfWork.SaveChangesAsync();
 
-             _notificationService.NotifyOutboundRequestCreatedAsync(request.OutboundRequestId, manager.ManagerId);
+            await _notificationService.NotifyOutboundRequestCreatedAsync(request.OutboundRequestId, manager.ManagerId);
 
             return new ServiceResult(Const.SUCCESS_CREATE_CODE, "Tạo yêu cầu xuất kho thành công", request.OutboundRequestId);
         }
 
-
         public async Task<IServiceResult> GetAllAsync(Guid userId)
         {
-            // Ưu tiên xác định là staff trước
             var staff = await _unitOfWork.BusinessStaffRepository.FindByUserIdAsync(userId);
             if (staff != null && !staff.IsDeleted)
             {
-                // Lọc theo supervisorId (tức manager của công ty)
-                var allRequests = await _unitOfWork.WarehouseOutboundRequests.GetAllAsync();
-                var filtered = allRequests
-                    .Where(r => r.RequestedBy == staff.SupervisorId)
-                    .ToList();
-
+                var filtered = await _unitOfWork.WarehouseOutboundRequests.GetAllAsync(
+                    r => r.RequestedBy == staff.SupervisorId && !r.IsDeleted);
                 if (!filtered.Any())
                     return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Không có yêu cầu xuất kho nào thuộc công ty bạn.", new List<WarehouseOutboundRequestListItemDto>());
-
                 return new ServiceResult(Const.SUCCESS_READ_CODE, "Lấy danh sách yêu cầu thành công", filtered.Select(x => x.ToListItemDto()).ToList());
             }
 
-            // Nếu không phải là staff, thử xem có phải manager không
             var manager = await _unitOfWork.BusinessManagerRepository.FindByUserIdAsync(userId);
             if (manager != null && !manager.IsDeleted)
             {
-                var allRequests = await _unitOfWork.WarehouseOutboundRequests.GetAllAsync();
-                var filtered = allRequests
-                    .Where(r => r.RequestedBy == manager.ManagerId)
-                    .ToList();
-
+                var filtered = await _unitOfWork.WarehouseOutboundRequests.GetAllAsync(
+                    r => r.RequestedBy == manager.ManagerId && !r.IsDeleted);
                 if (!filtered.Any())
                     return new ServiceResult(Const.WARNING_NO_DATA_CODE, "Không có yêu cầu xuất kho nào thuộc công ty bạn.", new List<WarehouseOutboundRequestListItemDto>());
-
                 return new ServiceResult(Const.SUCCESS_READ_CODE, "Lấy danh sách yêu cầu thành công", filtered.Select(x => x.ToListItemDto()).ToList());
             }
 
             return new ServiceResult(Const.FAIL_READ_CODE, "Không xác định được người dùng.");
         }
 
-
         public async Task<IServiceResult> GetDetailAsync(Guid outboundRequestId)
         {
             var request = await _unitOfWork.WarehouseOutboundRequests.GetByIdAsync(outboundRequestId);
-
             if (request == null || request.IsDeleted)
                 return new ServiceResult(Const.FAIL_READ_CODE, "Không tìm thấy yêu cầu xuất kho.");
-
             return new ServiceResult(Const.SUCCESS_READ_CODE, "Lấy chi tiết yêu cầu thành công", request.ToDetailDto());
         }
 
@@ -224,46 +146,51 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             if (inventory == null || inventory.IsDeleted)
                 return new ServiceResult(Const.FAIL_UPDATE_CODE, "Không tìm thấy tồn kho tương ứng.");
 
-            if (request.RequestedQuantity > inventory.Quantity)
-            {
-                return new ServiceResult(Const.FAIL_UPDATE_CODE,
-                    $"Tồn kho hiện tại chỉ còn {inventory.Quantity:n0} {inventory.Unit}, không thể duyệt yêu cầu {request.RequestedQuantity:n0}.");
-            }
+            // Quyền theo kho
+            var warehouse = await _unitOfWork.Warehouses.GetByIdAsync(inventory.WarehouseId);
+            if (warehouse?.ManagerId != staff.SupervisorId)
+                return new ServiceResult(Const.FAIL_UPDATE_CODE, "Bạn không có quyền duyệt yêu cầu cho kho này.");
 
-            // ✅ Kiểm tra hợp đồng nếu có
+            // Tồn khả dụng = tồn hiện tại - tổng Requested của các request Accepted chưa Completed cùng Inventory
+            var acceptedSameInventory = await _unitOfWork.WarehouseOutboundRequests.GetAllAsync(
+                r => r.InventoryId == request.InventoryId
+                     && !r.IsDeleted
+                     && r.Status == WarehouseOutboundRequestStatus.Accepted.ToString());
+            var reserved = acceptedSameInventory.Sum(r => r.RequestedQuantity);
+            var available = inventory.Quantity - reserved;
+            if (request.RequestedQuantity > available)
+                return new ServiceResult(Const.FAIL_UPDATE_CODE,
+                    $"Tồn khả dụng chỉ còn {available:n0} {inventory.Unit}.");
+
+            // Nếu gắn OrderItem → kiểm hạn mức: confirmed + accepted (kể cả request này) ≤ OrderItem.Quantity
             if (request.OrderItemId.HasValue)
             {
                 var orderItem = await _unitOfWork.OrderItemRepository.GetByIdAsync(
-                    predicate: oi =>
-                        oi.OrderItemId == request.OrderItemId.Value &&
-                        !oi.IsDeleted,
+                    predicate: oi => oi.OrderItemId == request.OrderItemId.Value && !oi.IsDeleted,
                     asNoTracking: true
                 );
-
                 if (orderItem == null)
                     return new ServiceResult(Const.FAIL_UPDATE_CODE, "Không tìm thấy dòng đơn hàng tương ứng.");
 
-                var approvedRequests = await _unitOfWork.WarehouseOutboundRequests.GetAllAsync(
-                    predicate: r =>
-                        r.OrderItemId == request.OrderItemId.Value &&
-                        !r.IsDeleted &&
-                        (r.Status == WarehouseOutboundRequestStatus.Accepted.ToString() ||
-                         r.Status == WarehouseOutboundRequestStatus.Completed.ToString())
-                );
+                var receiptsByOrderItem = await _unitOfWork.WarehouseOutboundReceipts.GetByOrderItemIdAsync(orderItem.OrderItemId);
+                double totalConfirmedOrderItem = receiptsByOrderItem
+                    .SelectMany(r => ParseConfirmedFromNote(r.Note))
+                    .Sum();
 
-                double totalApproved = approvedRequests.Sum(r => r.RequestedQuantity);
-                double allowedQuantity = orderItem.Quantity ?? 0.0;
-                double newQuantity = request.RequestedQuantity;
+                var acceptedSameOrderItem = await _unitOfWork.WarehouseOutboundRequests.GetAllAsync(
+                    r => r.OrderItemId == request.OrderItemId
+                         && !r.IsDeleted
+                         && r.Status == WarehouseOutboundRequestStatus.Accepted.ToString());
+                double totalAcceptedOutstanding = acceptedSameOrderItem.Sum(r => r.RequestedQuantity);
 
-                if (totalApproved + newQuantity > allowedQuantity)
-                {
+                var afterAccept = totalConfirmedOrderItem + totalAcceptedOutstanding + request.RequestedQuantity;
+                var allowedQuantity = orderItem.Quantity ?? 0.0;
+
+                if (afterAccept > allowedQuantity)
                     return new ServiceResult(Const.ERROR_VALIDATION_CODE,
-                        $"Duyệt yêu cầu này sẽ vượt quá giới hạn hợp đồng ({allowedQuantity:n0}). " +
-                        $"Đã duyệt: {totalApproved:n0}, lần này: {newQuantity:n0}.");
-                }
+                        $"Duyệt yêu cầu này sẽ vượt quá hạn mức của dòng đơn ({allowedQuantity:n0}). Đã xác nhận: {totalConfirmedOrderItem:n0}, đã duyệt khác: {totalAcceptedOutstanding:n0}, lần này: {request.RequestedQuantity:n0}.");
             }
 
-            // ✅ Cập nhật trạng thái
             request.Status = WarehouseOutboundRequestStatus.Accepted.ToString();
             request.UpdatedAt = DateTime.UtcNow;
 
@@ -272,7 +199,6 @@ namespace DakLakCoffeeSupplyChain.Services.Services
 
             return new ServiceResult(Const.SUCCESS_UPDATE_CODE, "Đã tiếp nhận yêu cầu xuất kho.");
         }
-
 
         public async Task<IServiceResult> CancelRequestAsync(Guid requestId, Guid managerUserId)
         {
@@ -295,6 +221,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
 
             return new ServiceResult(Const.SUCCESS_UPDATE_CODE, "Hủy yêu cầu xuất kho thành công.");
         }
+
         public async Task<IServiceResult> RejectRequestAsync(Guid requestId, Guid staffUserId, string rejectReason)
         {
             var request = await _unitOfWork.WarehouseOutboundRequests.GetByIdAsync(requestId);
@@ -305,7 +232,6 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             if (staff == null)
                 return new ServiceResult(Const.FAIL_UPDATE_CODE, "Không xác định được nhân viên xử lý.");
 
-            // ✅ Ghi đè lý do từ chối vào field Reason
             request.Status = WarehouseOutboundRequestStatus.Rejected.ToString();
             request.Reason = rejectReason;
             request.UpdatedAt = DateTime.UtcNow;
@@ -316,6 +242,20 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             return new ServiceResult(Const.SUCCESS_UPDATE_CODE, "Đã từ chối yêu cầu xuất kho.");
         }
 
+        // Helper parse [CONFIRMED:x] như bên ReceiptService
+        private IEnumerable<double> ParseConfirmedFromNote(string? note)
+        {
+            if (string.IsNullOrWhiteSpace(note)) yield break;
 
+            var tokens = note.Split("[CONFIRMED:", StringSplitOptions.RemoveEmptyEntries);
+            foreach (var token in tokens.Skip(1))
+            {
+                var end = token.IndexOf(']');
+                if (end <= 0) continue;
+                var valStr = token.Substring(0, end).Trim();
+                if (double.TryParse(valStr, out var val))
+                    yield return val;
+            }
+        }
     }
 }


### PR DESCRIPTION
☕ Feature: Add GetSummaryAsync for Outbound Request Summary (BE support for FE)
📌 Objective
Expose a lightweight summary API for an outbound request so the frontend can:

show “how much is left to export” correctly,

default the exported quantity to the remaining amount,

block over-exporting in real time.

✅ Key Changes
Implemented GetSummaryAsync(Guid requestId) in WarehouseOutboundReceiptService that aggregates:

requestedQuantity

confirmedQuantity (parsed from receipt Note tags like [CONFIRMED:x])

createdQuantity (sum of receipt Quantity)

draftQuantity = created - confirmed (non-confirmed portion of created receipts)

remainingByConfirm = requested - confirmed (business-valid remaining)

remainingHardCap = requested - created (strict cap if we wanted to block at create-time)

inventoryAvailable (current inventory of the request’s batch)

Added a new endpoint: GET /api/WarehouseOutboundReceipts/{id}/summary to return the summary to FE.

Updated controller to wire the new service method.

Extended IWarehouseOutboundReceiptService with the new signature.

🧱 Affected Files
Services/Services/WarehouseOutboundReceiptService.cs
→ Add GetSummaryAsync, reuse ParseConfirmedFromNote.

APIService/Controllers/WarehouseOutboundReceiptsController.cs
→ Add GET {id}/summary action (role BusinessStaff).

Services/IServices/IWarehouseOutboundReceiptService.cs
→ Add Task<IServiceResult> GetSummaryAsync(Guid requestId);

📁 Added
Endpoint: GET /api/WarehouseOutboundReceipts/{id}/summary
Returns aggregated summary for the outbound request {id}.

Sample response

json
Sao chép
Chỉnh sửa
{
  "requestedQuantity": 300,
  "confirmedQuantity": 150,
  "createdQuantity": 220,
  "draftQuantity": 70,
  "remainingByConfirm": 150,
  "remainingHardCap": 80,
  "inventoryAvailable": 500
}
FE will use min(remainingByConfirm, inventoryAvailable) as “Remaining exportable”.

🛠️ How to Test
Auth as a BusinessStaff (get JWT).

Create data (optional):

One outbound request (e.g., requestedQuantity = 300).

Create multiple receipts for that request; on some receipts, append confirm tags into Note like:
"... [CONFIRMED:100] ... [CONFIRMED:50]".

Call summary endpoint:

bash
Sao chép
Chỉnh sửa
curl -H "Authorization: Bearer <token>" \
https://localhost:7163/api/WarehouseOutboundReceipts/<outboundRequestId>/summary
Verify numbers match DB state and confirm tags.

🧪 Test Cases
 No receipts yet → confirmed=0, created=0, draft=0, remainingByConfirm=requested.

 Partially confirmed (e.g., CONFIRMED:150 for requested=300) → remainingByConfirm=150.

 Multiple confirms across receipts → sum all [CONFIRMED:x] across notes.

 Confirm > inventory (not allowed at confirm-time) → summary still reflects current inventory via inventoryAvailable.

 Deleted receipts ignored → only !IsDeleted receipts are counted.

 Floating numbers → tolerant parsing, ignore bad tags.

🔍 Notes
No DB/schema changes.

confirmedQuantity is derived only from [CONFIRMED:x] tokens in Note to support partial confirmations without altering stored Quantity.

The endpoint is read-only and safe to call frequently by FE.

FE can prevent duplicate simultaneous exports by:

reading remainingByConfirm,

disabling the submit button while a request is in-flight,

re-fetching summary after create/confirm actions.

🔗 Related
Module: Warehouse Outbound

Roles: BusinessStaff, Manager (view-only via FE)

FE usage: create outbound receipt page uses this endpoint to prefill and cap exportedQuantity.