### PR TITLE
refactor(business-buyer): enforce role-based authorization in update logic

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessBuyersController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/BusinessBuyersController.cs
@@ -127,11 +127,14 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
                 return BadRequest(ModelState);
 
             Guid userId;
+            string userRole;
 
             try
             {
-                // Lấy userId từ token qua ClaimsHelper
+                // Lấy userId và userRole từ token qua ClaimsHelper
                 userId = User.GetUserId();
+                userRole = User.GetRole();
+
             }
             catch
             {
@@ -139,7 +142,7 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             }
 
             var result = await _businessBuyerService
-                .Update(businessBuyerDto, userId);
+                .Update(businessBuyerDto, userId, userRole);
 
             if (result.Status == Const.SUCCESS_UPDATE_CODE)
                 return Ok(result.Data);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessBuyerService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IBusinessBuyerService.cs
@@ -16,7 +16,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
 
         Task<IServiceResult> Create(BusinessBuyerCreateDto businessBuyerDto, Guid userId);
 
-        Task<IServiceResult> Update(BusinessBuyerUpdateDto businessBuyerDto, Guid userId);
+        Task<IServiceResult> Update(BusinessBuyerUpdateDto businessBuyerDto, Guid userId, string userRole);
 
         Task<IServiceResult> DeleteBusinessBuyerById(Guid buyerId, Guid userId);
 

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/BusinessBuyerService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/BusinessBuyerService.cs
@@ -133,7 +133,8 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             }
         }
 
-        public async Task<IServiceResult> Create(BusinessBuyerCreateDto businessBuyerDto, Guid userId)
+        public async Task<IServiceResult> Create(
+            BusinessBuyerCreateDto businessBuyerDto, Guid userId)
         {
             try
             {
@@ -191,13 +192,16 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 }
 
                 // Sinh mã định danh cho BusinessBuyer
-                string buyerCode = await _codeGenerator.GenerateBuyerCodeAsync(managerId);
+                string buyerCode = await _codeGenerator
+                    .GenerateBuyerCodeAsync(managerId);
 
                 // Ánh xạ dữ liệu từ DTO vào entity
-                var newBusinessBuyer = businessBuyerDto.MapToNewBusinessBuyer(managerId, buyerCode);
+                var newBusinessBuyer = businessBuyerDto
+                    .MapToNewBusinessBuyer(managerId, buyerCode);
 
                 // Tạo Business Buyer ở repository
-                await _unitOfWork.BusinessBuyerRepository.CreateAsync(newBusinessBuyer);
+                await _unitOfWork.BusinessBuyerRepository
+                    .CreateAsync(newBusinessBuyer);
 
                 // Lưu thay đổi vào database
                 var result = await _unitOfWork.SaveChangesAsync();
@@ -232,7 +236,8 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             }
         }
 
-        public async Task<IServiceResult> Update(BusinessBuyerUpdateDto businessBuyerDto, Guid userId)
+        public async Task<IServiceResult> Update(
+            BusinessBuyerUpdateDto businessBuyerDto, Guid userId, string userRole)
         {
             try
             {
@@ -257,8 +262,8 @@ namespace DakLakCoffeeSupplyChain.Services.Services
 
                 // Kiểm tra role
                 if (businessManager.User.IsDeleted ||
-                    businessManager.User.Role == null ||
-                    businessManager.User.Role.RoleName != "BusinessManager")
+                    userRole == null ||
+                    userRole != "BusinessManager")
                 {
                     return new ServiceResult(
                         Const.FAIL_UPDATE_CODE,
@@ -321,7 +326,8 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 businessBuyerDto.MapToUpdateBusinessBuyer(businessBuyer);
 
                 // Cập nhật buyer ở repository
-                await _unitOfWork.BusinessBuyerRepository.UpdateAsync(businessBuyer);
+                await _unitOfWork.BusinessBuyerRepository
+                    .UpdateAsync(businessBuyer);
 
                 // Lưu thay đổi vào database
                 var result = await _unitOfWork.SaveChangesAsync();
@@ -398,7 +404,8 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 else
                 {
                     // Xóa buyer khỏi repository
-                    await _unitOfWork.BusinessBuyerRepository.RemoveAsync(businessBuyer);
+                    await _unitOfWork.BusinessBuyerRepository
+                        .RemoveAsync(businessBuyer);
 
                     // Lưu thay đổi
                     var result = await _unitOfWork.SaveChangesAsync();
@@ -474,7 +481,8 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                     businessBuyer.UpdatedAt = DateHelper.NowVietnamTime();
 
                     // Cập nhật xoá mềm buyer ở repository
-                    await _unitOfWork.BusinessBuyerRepository.UpdateAsync(businessBuyer);
+                    await _unitOfWork.BusinessBuyerRepository
+                        .UpdateAsync(businessBuyer);
 
                     // Lưu thay đổi
                     var result = await _unitOfWork.SaveChangesAsync();


### PR DESCRIPTION
## ☕ Feature: Update BusinessBuyer with role-based authorization

### 📌 Objective
Refactor `BusinessBuyer` update flow to enforce **role-based authorization**, ensuring that only users with the `BusinessManager` role can perform updates.  
This improves data security and prevents unauthorized modifications.

---

### ✅ Key Changes
- Retrieve `userRole` from JWT claims in `BusinessBuyersController`
- Pass `userRole` to `BusinessBuyerService.Update()` method
- Validate that the user has `BusinessManager` role before proceeding
- Return appropriate error messages for unauthorized access
- Maintain existing validations for ID matching and ModelState

---

### 🧱 Affected Files
- `BusinessBuyersController.cs`
- `IBusinessBuyerService.cs`
- `BusinessBuyerService.cs`

---

### 📁 Added
- N/A

---

### 🛠️ How to Test
1. **Login** with `BusinessManager` account to obtain JWT token  
2. Send request to endpoint:  
   - `PUT /api/businessbuyers/{buyerId}`  
   - Header: `Authorization: Bearer {token}`  
3. Sample body:
```json
{
  "buyerId": "c8a1f2ab-3f2b-4c9c-a982-4569c65789ab",
  "companyName": "ABC Coffee Ltd",
  "taxId": "1234567890",
  "phone": "0901234567",
  "email": "contact@abccoffee.com",
  "address": "123 Dak Lak"
}
```

---

### 🧪 Test Cases
- [x] ✅ Update with valid **BusinessManager** token → success  
- [x] ❌ Update with non-**BusinessManager** role → blocked with error message  
- [x] 🔄 ID in route and body mismatch → returns **BadRequest**

---

### 🔍 Notes
- Uses `User.GetUserId()` and `User.GetRole()` from JWT claims  
- Only active **BusinessManager** accounts are allowed to update  
- No DB schema changes; logic-level refactor only

---

### 🔗 Related
- **Modules:** `BusinessBuyer`, `BusinessManager`  
- **Roles:** `BusinessManager`
