### PR TITLE
feat: Add BusinessManager role support for crop season management...

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropProgressesController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropProgressesController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Query;
+using System.Security.Claims;
 
 namespace DakLakCoffeeSupplyChain.APIService.Controllers
 {
@@ -52,8 +53,12 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             try { userId = User.GetUserId(); }
             catch { return Unauthorized("Không xác định được userId từ token."); }
 
+            var role = User.FindFirst(ClaimTypes.Role)?.Value;
+            bool isAdmin = role == "Admin";
+            bool isManager = role == "BusinessManager";
+
             var result = await _cropProgressService
-                .GetByCropSeasonDetailId(cropSeasonDetailId, userId);
+                .GetByCropSeasonDetailId(cropSeasonDetailId, userId, isAdmin, isManager);
 
             if (result.Status == Const.SUCCESS_READ_CODE)
                 return Ok(result.Data);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropSeasonsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/CropSeasonsController.cs
@@ -63,8 +63,12 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
             try { userId = User.GetUserId(); }
             catch { return Unauthorized("Không xác định được userId từ token."); }
 
+            var role = User.FindFirst(ClaimTypes.Role)?.Value;
+            bool isAdmin = role == "Admin";
+            bool isManager = role == "BusinessManager";
+
             var result = await _cropSeasonService
-                .GetById(cropSeasonId, userId);
+                .GetById(cropSeasonId, userId, isAdmin, isManager);
 
             if (result.Status == Const.SUCCESS_READ_CODE) 
                 return Ok(result.Data);

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropProgressRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/ICropProgressRepository.cs
@@ -14,6 +14,7 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
         Task<List<CropProgress>> GetAllWithIncludesAsync();
 
         Task<List<CropProgress>> GetByCropSeasonDetailIdWithIncludesAsync(Guid cropSeasonDetailId, Guid userId);
+        Task<List<CropProgress>> GetByCropSeasonDetailIdForManagerAsync(Guid cropSeasonDetailId);
 
         Task<CropProgress?> GetByIdWithDetailAsync(Guid progressId);
 

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropProgressRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/CropProgressRepository.cs
@@ -55,6 +55,26 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
                 .ToListAsync();
         }
 
+        public async Task<List<CropProgress>> GetByCropSeasonDetailIdForManagerAsync(
+            Guid cropSeasonDetailId)
+        {
+            return await _context.CropProgresses
+                .AsNoTracking()
+                .Where(p => !p.IsDeleted &&
+                            p.CropSeasonDetailId == cropSeasonDetailId)
+                .Include(p => p.Stage)
+                .Include(p => p.UpdatedByNavigation)
+                   .ThenInclude(f => f.User)
+                .Include(p => p.CropSeasonDetail)
+                    .ThenInclude(d => d.CropSeason)
+                        .ThenInclude(cs => cs.Farmer)
+                            .ThenInclude(f => f.User)
+                .OrderBy(p => p.StageId)
+                .ThenBy(p => p.StepIndex ?? 0)
+                .ThenBy(p => p.ProgressDate)
+                .ToListAsync();
+        }
+
         public async Task<List<CropProgress>> FindAsync(
             Expression<Func<CropProgress, bool>> predicate)
         {

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropProgressService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropProgressService.cs
@@ -2,6 +2,7 @@
 using DakLakCoffeeSupplyChain.Common.DTOs.CropProgressDTOs;
 using DakLakCoffeeSupplyChain.Common.Enum.CropSeasonEnums;
 using DakLakCoffeeSupplyChain.Common.Helpers;
+using DakLakCoffeeSupplyChain.Repositories.Models;
 using DakLakCoffeeSupplyChain.Repositories.UnitOfWork;
 using DakLakCoffeeSupplyChain.Services.Base;
 using DakLakCoffeeSupplyChain.Services.IServices;
@@ -52,8 +53,20 @@ namespace DakLakCoffeeSupplyChain.Services.Services
         {
             try
             {
-                var progresses = await _unitOfWork.CropProgressRepository
-                    .GetByCropSeasonDetailIdWithIncludesAsync(cropSeasonDetailId, userId);
+                List<CropProgress> progresses;
+                
+                if (isAdmin || isManager)
+                {
+                    // Admin và Manager có thể xem tất cả progress
+                    progresses = await _unitOfWork.CropProgressRepository
+                        .GetByCropSeasonDetailIdForManagerAsync(cropSeasonDetailId);
+                }
+                else
+                {
+                    // Farmer chỉ xem được progress của mình
+                    progresses = await _unitOfWork.CropProgressRepository
+                        .GetByCropSeasonDetailIdWithIncludesAsync(cropSeasonDetailId, userId);
+                }
 
                 var result = new CropProgressViewByDetailDto
                 {

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropSeasonService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CropSeasonService.cs
@@ -60,7 +60,7 @@ namespace DakLakCoffeeSupplyChain.Services.Services
             if (cropSeason == null)
                 return new ServiceResult(Const.WARNING_NO_DATA_CODE, Const.WARNING_NO_DATA_MSG);
 
-            if (!isAdmin && cropSeason.Farmer?.UserId != userId)
+            if (!isAdmin && !isManager && cropSeason.Farmer?.UserId != userId)
                 return new ServiceResult(Const.FAIL_READ_CODE, "Bạn không có quyền truy cập mùa vụ này.");
 
             var registration = cropSeason.Commitment?.Registration;


### PR DESCRIPTION
## ☕ Feature: BusinessManager Crop Season Management API

### �� Objective
Thêm quyền truy cập cho role BusinessManager để xem và quản lý tất cả mùa vụ cà phê của nông dân trong hệ thống. BusinessManager cần có khả năng theo dõi tổng quan mùa vụ, xem chi tiết vùng trồng và tiến độ canh tác của tất cả farmer.

---

### ✅ Key Changes
- Cập nhật CropSeasonsController để truyền tham số `isManager` vào service layer
- Sửa logic permission trong CropSeasonService cho phép BusinessManager xem tất cả mùa vụ
- Tạo method mới `GetByCropSeasonDetailIdForManagerAsync` trong CropProgressRepository
- Cập nhật CropProgressService để BusinessManager có thể xem tất cả progress
- Thêm role-based authorization logic với ClaimTypes.Role

---

### �� Affected Files
- `Controllers/CropSeasonsController.cs`
- `Services/CropSeasonService.cs`
- `Services/CropProgressService.cs`
- `IRepositories/ICropProgressRepository.cs`
- `Repositories/CropProgressRepository.cs`

---

### 📁 Added
- Method `GetByCropSeasonDetailIdForManagerAsync` trong ICropProgressRepository và CropProgressRepository

---

### ��️ How to Test
1. **Login** bằng role `BusinessManager` để lấy JWT token
2. Gửi request đến endpoints:
   - `GET /api/CropSeasons` - Lấy danh sách tất cả mùa vụ
   - `GET /api/CropSeasons/{id}` - Xem chi tiết mùa vụ cụ thể
   - `GET /api/CropProgresses/by-detail/{detailId}` - Xem progress của vùng trồng
3. Header: `Authorization: Bearer {token}`

---

### �� Test Cases
- [x] ✅ **BusinessManager Access**: BusinessManager có thể xem tất cả mùa vụ của mọi farmer
- [x] ✅ **Farmer Restriction**: Farmer chỉ có thể xem mùa vụ của chính mình
- [x] ✅ **Admin Access**: Admin có thể xem tất cả mùa vụ
- [x] ❌ **Unauthorized Access**: Role không có quyền bị từ chối truy cập

---

### 🔍 Notes
- Sử dụng ClaimTypes.Role để xác định role từ JWT token
- Logic permission được implement ở service layer để đảm bảo security
- BusinessManager có quyền read-only, không thể tạo/sửa/xóa mùa vụ
- 💡 Có thể mở rộng thêm quyền export data hoặc tạo báo cáo tổng hợp

---

### �� Related
- Modules: `CropSeason`, `CropSeasonDetail`, `CropProgress`
- Roles: `Admin`, `BusinessManager`, `Farmer`, `Expert`