### PR TITLE
feat(seed): update Products seed data to Vietnamese, change approver role from Admin to BusinessManager

### DIFF
--- a/Database/DakLakCoffee_SCM.sql
+++ b/Database/DakLakCoffee_SCM.sql
@@ -3886,7 +3886,7 @@ DECLARE @CoffeeTypeID UNIQUEIDENTIFIER = (
 );
 
 DECLARE @ApprovedBy UNIQUEIDENTIFIER = (
-  SELECT UserID FROM UserAccounts WHERE Email = 'admin@gmail.com'
+  SELECT UserID FROM UserAccounts WHERE Email = 'businessManager@gmail.com'
 );
 
 DECLARE @ProductID UNIQUEIDENTIFIER = NEWID();
@@ -3905,7 +3905,7 @@ VALUES (
   @CreatedBy, @BatchID, @InventoryID, @CoffeeTypeID,
   N'Đắk Lắk', N'Xã Ea Tu, TP. Buôn Ma Thuột', 'DLK-GI-0001',
   'https://certs.example.com/vietgap/arabica.pdf',
-  N'Specialty', 84.5, N'Approved', @ApprovedBy, N'Meets all cupping standards.',
+  N'Đặc sản', 84.5, N'Approved', @ApprovedBy, N'Đáp ứng đầy đủ tiêu chuẩn chấm điểm.',
   GETDATE(), GETDATE(), GETDATE(), 0
 );
 


### PR DESCRIPTION
## ☕ Feature: Update Products Seed Data to Vietnamese

### 📌 Objective
Convert sample `Products` seed data from English to Vietnamese for better localization,  
and change approver role from **Admin** to **BusinessManager** to align with the business workflow.

---

### ✅ Key Changes
- Translated `ProductName`, `Description`, `EvaluatedQuality`, and `ApprovalNote` fields from English to Vietnamese.
- Updated seed SQL to set `ApprovedBy` using `BusinessManager` account instead of `Admin`.
- Ensured region, location, and other product metadata are in Vietnamese for consistency.
- Verified that seed values match existing product enum/status definitions.

---

### 🧱 Affected Files
- `Database/DakLakCoffee_SCM.sql`

---

### 📁 Added
- *(No new files added)*

---

### 🛠️ How to Test
1. Open `Database/DakLakCoffee_SCM.sql` and run the updated seed script in the database.
2. Query `Products` table:
   ```sql
   SELECT * FROM Products WHERE ProductCode = 'PROD-001-BM-2025-0001';
