### PR TITLE
feat(delivery-batch): enforce 4 create validations (rounds limit, contract sum(planned) ≤ Contract.TotalQuantity, batch items sum ≤ Batch.TotalPlannedQuantity, per-ContractItem sum(planned) ≤ ContractItem.Quantity); repo helpers: CountAsync, SumAsync, SumPlannedByContractGroupedAsync

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IContractDeliveryBatchRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IContractDeliveryBatchRepository.cs
@@ -3,6 +3,7 @@ using DakLakCoffeeSupplyChain.Repositories.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -12,5 +13,19 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
     {
         // Đếm số lô giao hàng hợp đồng được tạo trong năm chỉ định
         Task<int> CountByYearAsync(int year);
+
+        Task<int> CountAsync(Expression<Func<ContractDeliveryBatch, bool>>? predicate = null);
+
+        // Sum cho double?
+        Task<double?> SumAsync(
+            Expression<Func<ContractDeliveryBatch, double?>> selector,
+            Expression<Func<ContractDeliveryBatch, bool>>? predicate = null
+        );
+
+        // Sum cho decimal?
+        Task<decimal?> SumAsync(
+            Expression<Func<ContractDeliveryBatch, decimal?>> selector,
+            Expression<Func<ContractDeliveryBatch, bool>>? predicate = null
+        );
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IContractDeliveryItemRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/IRepositories/IContractDeliveryItemRepository.cs
@@ -18,5 +18,8 @@ namespace DakLakCoffeeSupplyChain.Repositories.IRepositories
 
         // Đếm số item trong danh mục giao của hợp đồng
         Task<int> CountByDeliveryBatchIdAsync(Guid deliveryBatchId);
+
+        // tổng PlannedQuantity theo từng ContractItemId của 1 hợp đồng (gộp tất cả đợt, bỏ soft-delete)
+        Task<Dictionary<Guid, double>> SumPlannedByContractGroupedAsync(Guid contractId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ContractDeliveryBatchRepository.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Repositories/Repositories/ContractDeliveryBatchRepository.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -23,10 +24,39 @@ namespace DakLakCoffeeSupplyChain.Repositories.Repositories
         {
             return await _context.ContractDeliveryBatches
                 .CountAsync(cdb =>
-                    !cdb.IsDeleted &&
                     cdb.CreatedAt.HasValue &&
                     cdb.CreatedAt.Value.Year == year
                 );
+        }
+
+        public async Task<int> CountAsync(Expression<Func<ContractDeliveryBatch, bool>>? predicate = null)
+        {
+            IQueryable<ContractDeliveryBatch> query = _context.ContractDeliveryBatches.AsNoTracking();
+            if (predicate != null) query = query.Where(predicate);
+
+            return await query.CountAsync();
+        }
+
+        // Sum cho double?
+        public async Task<double?> SumAsync(
+            Expression<Func<ContractDeliveryBatch, double?>> selector,
+            Expression<Func<ContractDeliveryBatch, bool>>? predicate = null)
+        {
+            IQueryable<ContractDeliveryBatch> query = _context.ContractDeliveryBatches.AsNoTracking();
+            if (predicate != null) query = query.Where(predicate);
+
+            return await query.SumAsync(selector);
+        }
+
+        // Sum cho decimal?
+        public async Task<decimal?> SumAsync(
+            Expression<Func<ContractDeliveryBatch, decimal?>> selector,
+            Expression<Func<ContractDeliveryBatch, bool>>? predicate = null)
+        {
+            IQueryable<ContractDeliveryBatch> query = _context.ContractDeliveryBatches.AsNoTracking();
+            if (predicate != null) query = query.Where(predicate);
+
+            return await query.SumAsync(selector);
         }
     }
 }


### PR DESCRIPTION
## ☕ Feature: ContractDeliveryBatch – Create validations & repository helpers

### 📌 Objective
Add strict business validations when **creating Contract Delivery Batches** and provide repository helpers to support aggregate checks. This ensures delivery scheduling and quantities stay within the limits defined by the contract and each contract item. Target flow: **BusinessManager / BusinessStaff** managing contract deliveries.

---

### ✅ Key Changes
- **Validation #1 – Rounds limit:**  
  Block create when existing batches (non-deleted) **≥ `Contract.DeliveryRounds`** and validate `DeliveryRound ∈ [1..DeliveryRounds]`.
- **Validation #2 – Contract total cap:**  
  Enforce **Σ `TotalPlannedQuantity` of all batches (existing + new) ≤ `Contract.TotalQuantity`**.
- **Validation #3 – Batch items cap:**  
  Enforce **Σ `PlannedQuantity` of items in the request ≤ `ContractDeliveryBatch.TotalPlannedQuantity`**.
- **Validation #4 – Per-ContractItem cumulative cap:**  
  For each `ContractItemId`, **Σ planned across all batches + planned in current request ≤ `ContractItem.Quantity`**.
- **Repository helpers:**  
  Add `CountAsync`, `SumAsync` for batches and `SumPlannedByContractGroupedAsync` for delivery items; ignore soft-deleted rows.
- **Includes:** Ensure `Contract.ContractItems` (and `CoffeeType`) are loaded for per-item validation.

---

### 🧱 Affected Files
- `DakLakCoffeeSupplyChain.Repositories/IRepositories/IContractDeliveryBatchRepository.cs`
- `DakLakCoffeeSupplyChain.Repositories/IRepositories/IContractDeliveryItemRepository.cs`
- `DakLakCoffeeSupplyChain.Repositories/Repositories/ContractDeliveryBatchRepository.cs`
- `DakLakCoffeeSupplyChain.Repositories/Repositories/ContractDeliveryItemRepository.cs`
- `DakLakCoffeeSupplyChain.Services/Services/ContractDeliveryBatchService.cs`

---

### 📁 Added
- Repo methods:  
  - `CountAsync(predicate)`  
  - `SumAsync(selector, predicate)`  
  - `SumPlannedByContractGroupedAsync(contractId)`

---

### 🛠️ How to Test
1. **Login** as `BusinessManager` (or `BusinessStaff` under a manager) to obtain a JWT.
2. Create a contract with:  
   - `DeliveryRounds = 3`, `TotalQuantity = 10_000` (kg)  
   - Several `ContractItems` with quantities (e.g., Robusta 6,000; Arabica 4,000).
3. Call endpoint:
   - `POST /api/contract-delivery-batches`
   - `Authorization: Bearer {token}`
4. Sample body:
```json
{
  "ContractId": "11111111-1111-1111-1111-111111111111",
  "DeliveryRound": 2,
  "ExpectedDeliveryDate": "2025-08-18",
  "TotalPlannedQuantity": 3000,
  "Note": "Round 2 planning",
  "ContractDeliveryItems": [
    {
      "ContractItemId": "22222222-2222-2222-2222-222222222222",
      "PlannedQuantity": 1000,
      "Note": "Robusta"
    }
  ]
}
```

---

### 🧪 Test Cases

- [ ] ✅ **OK:** total batches < `DeliveryRounds`, `DeliveryRound` within range, sums within all caps → create succeeds.
- [ ] ❌ **Rounds limit:** existing batches = `DeliveryRounds` → create rejected.
- [ ] ❌ **DeliveryRound out of range:** `DeliveryRound` = 0 or > `DeliveryRounds` → rejected.
- [ ] ❌ **Contract total cap:** Σ batches (existing + new) > `Contract.TotalQuantity` → rejected.
- [ ] ❌ **Batch items cap:** Σ items in request > `TotalPlannedQuantity` → rejected.
- [ ] ❌ **Per-item cumulative cap:** For a given `ContractItemId`, Σ planned across all batches + request > `ContractItem.Quantity` → rejected.
- [ ] ❌ **Foreign item:** Item not belonging to the contract → rejected.

---

### 🔍 Notes

- Soft-deleted batches/items are **excluded** from all aggregates.
- Ensure `ContractItems` are **included** (or fetched separately) before per-item validation.
- Use consistent numeric type (**double** vs **decimal**) across entities & sums to avoid precision issues.
- Dates: `DateOnly` for contract range; validate `ExpectedDeliveryDate` within `[StartDate..EndDate]`.
- Authorization: only **Manager** (or **Staff** under Manager) of `SellerId` can create batches.

---

### 🔗 Related

- **Modules:** `Contracts`, `ContractDeliveryBatch`, `ContractDeliveryItem`
- **Roles:** `BusinessManager`, `BusinessStaff`
