### PR TITLE
refactor(Cultivation registration) Add validations checking if plan is still open for farmer to apply registration

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CultivationRegistrationService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/CultivationRegistrationService.cs
@@ -269,11 +269,11 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                     asNoTracking: true
                     );
 
-                // Kiểm tra xem plan được chọn có tồn tại không
-                if (selectedProcurementPlan == null)
+                // Kiểm tra xem plan được chọn có tồn tại và còn mở không
+                if (selectedProcurementPlan == null || selectedProcurementPlan.Status != "Open")
                     return new ServiceResult(
                             Const.WARNING_NO_DATA_CODE,
-                            "Kế hoạch thu mua được chọn không tồn tại"
+                            "Kế hoạch thu mua được chọn không tồn tại hoặc không còn mở"
                         );
 
                 // Lấy các plan detail id từ plan mẹ được chọn trong hệ thống


### PR DESCRIPTION
- Add validation in the Cultivation Registration process to check whether the related procurement plan or cultivation plan is still open and available for farmers to apply.
- Implement this validation in both the backend API and service layers to prevent registrations against closed or expired plans.
- Ensure that the validation logic verifies the plan’s status or open/close period before allowing a new registration submission.
- Provide clear and user-friendly error messages when a farmer tries to register for a plan that is no longer open.
- Update the registration DTOs or request handlers to include necessary identifiers for plan validation.
- Reflect this validation in the frontend UI by disabling or hiding registration options for closed plans if applicable.
- Write unit and integration tests to cover cases where plans are open or closed to ensure correct enforcement.
- Update API documentation and user guides to include the new validation check for plan availability.
