### PR TITLE
feat(payment-config): add hard delete API (Controller, Service, DTO)

### DIFF
--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/PaymentConfigurationsController.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.APIService/Controllers/PaymentConfigurationsController.cs
@@ -53,5 +53,25 @@ namespace DakLakCoffeeSupplyChain.APIService.Controllers
 
             return StatusCode(500, result.Message);  // Lỗi hệ thống
         }
+
+        // DELETE api/<PaymentConfigurationsController>/{configId}
+        [HttpDelete("{configId}")]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> DeletePaymentConfigurationByIdAsync(Guid configId)
+        {
+            var result = await _paymentConfigurationService
+                .DeletePaymentConfigurationById(configId);
+
+            if (result.Status == Const.SUCCESS_DELETE_CODE)
+                return Ok("Xóa thành công.");
+
+            if (result.Status == Const.WARNING_NO_DATA_CODE)
+                return NotFound("Không tìm thấy loại phí cần xóa.");
+
+            if (result.Status == Const.FAIL_DELETE_CODE)
+                return Conflict("Xóa thất bại.");
+
+            return StatusCode(500, result.Message);
+        }
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/PaymentConfigurationDtos/PaymentConfigurationDeleteDto.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Common/DTOs/PaymentConfigurationDtos/PaymentConfigurationDeleteDto.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DakLakCoffeeSupplyChain.Common.DTOs.PaymentConfigurationDtos
+{
+    public class PaymentConfigurationDeleteDto
+    {
+        public Guid ConfigId { get; set; }
+    }
+}

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IPaymentConfigurationService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/IServices/IPaymentConfigurationService.cs
@@ -12,5 +12,7 @@ namespace DakLakCoffeeSupplyChain.Services.IServices
         Task<IServiceResult> GetAll();
 
         Task<IServiceResult> GetById(Guid configId);
+
+        Task<IServiceResult> DeletePaymentConfigurationById(Guid configId);
     }
 }

--- a/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/PaymentConfigurationService.cs
+++ b/Source/DakLakCoffeeSupplyChainBE/DakLakCoffeeSupplyChain.Services/Services/PaymentConfigurationService.cs
@@ -93,5 +93,57 @@ namespace DakLakCoffeeSupplyChain.Services.Services
                 );
             }
         }
+
+        public async Task<IServiceResult> DeletePaymentConfigurationById(Guid configId)
+        {
+            try
+            {
+                // Tìm PaymentConfiguration theo ID
+                var paymentConfiguration = await _unitOfWork.PaymentConfigurationRepository
+                    .GetByIdAsync(configId);
+
+                // Kiểm tra nếu không tồn tại
+                if (paymentConfiguration == null)
+                {
+                    return new ServiceResult(
+                        Const.WARNING_NO_DATA_CODE,
+                        Const.WARNING_NO_DATA_MSG
+                    );
+                }
+                else
+                {
+                    // Xóa paymentConfiguration khỏi repository
+                    await _unitOfWork.PaymentConfigurationRepository
+                        .RemoveAsync(paymentConfiguration);
+
+                    // Lưu thay đổi
+                    var result = await _unitOfWork.SaveChangesAsync();
+
+                    // Kiểm tra kết quả
+                    if (result > 0)
+                    {
+                        return new ServiceResult(
+                            Const.SUCCESS_DELETE_CODE,
+                            Const.SUCCESS_DELETE_MSG
+                        );
+                    }
+                    else
+                    {
+                        return new ServiceResult(
+                            Const.FAIL_DELETE_CODE,
+                            Const.FAIL_DELETE_MSG
+                        );
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Trả về lỗi nếu có exception
+                return new ServiceResult(
+                    Const.ERROR_EXCEPTION,
+                    ex.ToString()
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## ☕ Feature: Hard Delete PaymentConfiguration API

### 📌 Objective
Introduce a new API endpoint that allows **Admin** to permanently delete a `PaymentConfiguration` by its `configId`.  
This supports system maintenance by removing outdated or invalid payment fee configurations from the database.

---

### ✅ Key Changes
- Implemented **hard delete** endpoint in `PaymentConfigurationsController`.
- Added service logic `DeletePaymentConfigurationById` in `PaymentConfigurationService`.
- Updated `IPaymentConfigurationService` interface with delete method.
- Created `PaymentConfigurationDeleteDto` (if needed for future responses).
- Integrated with repository `RemoveAsync` + `SaveChangesAsync`.

---

### 🧱 Affected Files
- `PaymentConfigurationsController.cs`
- `IPaymentConfigurationService.cs`
- `PaymentConfigurationService.cs`

---

### 📁 Added
- `PaymentConfigurationDeleteDto.cs`

---

### 🛠️ How to Test
1. **Login** as `Admin` and obtain JWT token.
2. Send request to endpoint:
   - `DELETE /api/PaymentConfigurations/{configId}`
   - Header: `Authorization: Bearer {token}`

---

### 🧪 Test Cases
- [x] ✅ Valid `configId` → returns **200 OK** with success message.  
- [x] ❌ Non-existing `configId` → returns **404 Not Found**.  
- [x] ❌ Without `Admin` role → returns **403 Forbidden**.  
- [x] ❌ DB SaveChanges returns 0 → returns **409 Conflict**.  
- [x] ❌ Unexpected error → returns **500 InternalServerError** with error message.  

---

### 🔍 Notes
- This implementation performs **hard delete** (entity removed from DB).  
- Consider switching to **soft delete** in the future (`IsActive = false`) to preserve history and references.  
- Endpoint secured with `[Authorize(Roles = "Admin")]`.  

---

### 🔗 Related
- Modules: `PaymentConfiguration`
- Roles: `Admin`
